### PR TITLE
Rename to portable-simd and remove other names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# stdsimd - Rust's standard library portable SIMD API
-[![Build Status](https://travis-ci.com/rust-lang/stdsimd.svg?branch=master)](https://travis-ci.com/rust-lang/stdsimd)
+# The Rust standard library's portable SIMD API
+[![Build Status](https://travis-ci.com/rust-lang/portable-simd.svg?branch=master)](https://travis-ci.com/rust-lang/portable-simd)
 
 Code repository for the [Portable SIMD Project Group](https://github.com/rust-lang/project-portable-simd).
 Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for our contributing guidelines.
@@ -31,7 +31,7 @@ name = "hellosimd"
 version = "0.1.0"
 edition = "2018"
 [dependencies]
-core_simd = { git = "https://github.com/rust-lang/stdsimd" }
+core_simd = { git = "https://github.com/rust-lang/portable-simd" }
 ```
 
 and finally write this in `src/main.rs`:
@@ -66,4 +66,4 @@ The `mask` types are "truthy" values, but they use the number of bits in their n
 [simd-guide]: ./beginners-guide.md
 [zulip-project-portable-simd]: https://rust-lang.zulipchat.com/#narrow/stream/257879-project-portable-simd
 [stdarch]: https://github.com/rust-lang/stdarch
-[docs]: https://rust-lang.github.io/stdsimd/core_simd
+[docs]: https://rust-lang.github.io/portable-simd/core_simd

--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "core_simd"
 version = "0.1.0"
-authors = ["Caleb Zulawski <caleb.zulawski@gmail.com>"]
 edition = "2018"
-homepage = "https://github.com/rust-lang/stdsimd"
-repository = "https://github.com/rust-lang/stdsimd"
+homepage = "https://github.com/rust-lang/portable-simd"
+repository = "https://github.com/rust-lang/portable-simd"
 keywords = ["core", "simd", "intrinsics"]
 categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test_helpers"
 version = "0.1.0"
-authors = ["Caleb Zulawski <caleb.zulawski@gmail.com>"]
 edition = "2018"
 publish = false
 


### PR DESCRIPTION
Clean up references to the repo's previous name.
Removes the authors field, which is non-obligatory since RFC 3052.
Better to omit than confound: let git log be our witness.