### PR TITLE
Cleanup more for std::simd also

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -16,4 +16,5 @@
 
 #[path = "mod.rs"]
 mod core_simd;
-pub use self::core_simd::simd::*;
+use self::core_simd::simd;
+pub use simd::*;

--- a/crates/core_simd/src/mod.rs
+++ b/crates/core_simd/src/mod.rs
@@ -3,31 +3,29 @@ mod permute;
 #[macro_use]
 mod reduction;
 
-mod select;
+pub(crate) mod intrinsics;
 
 #[cfg(feature = "generic_const_exprs")]
 mod to_bytes;
 
 mod comparisons;
 mod fmt;
-mod intrinsics;
 mod iter;
+mod lane_count;
+mod masks;
 mod math;
 mod ops;
 mod round;
-mod vendor;
-
-mod lane_count;
-
-mod masks;
-
+mod select;
 mod vector;
+mod vendor;
 
 #[doc = include_str!("core_simd_docs.md")]
 pub mod simd {
-    pub use crate::core_simd::lane_count::*;
+    pub(crate) use crate::core_simd::intrinsics;
+
+    pub use crate::core_simd::lane_count::{LaneCount, SupportedLaneCount};
     pub use crate::core_simd::masks::*;
     pub use crate::core_simd::select::Select;
     pub use crate::core_simd::vector::*;
-    pub(crate) use crate::core_simd::*;
 }


### PR DESCRIPTION
Just a few more tweaks (cleanup, really) that surfaced while finishing plumbing `use core::simd` into `std::simd` also.