### PR TITLE
Add lanes()

### DIFF
--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -24,6 +24,9 @@ where
     LaneCount<LANES>: SupportedLaneCount,
     T: SimdElement,
 {
+    /// Number of lanes in this vector.
+    pub const LANES: usize = LANES;
+
     /// Get the number of lanes in this vector.
     pub const fn lanes(&self) -> usize {
         LANES

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -24,6 +24,11 @@ where
     LaneCount<LANES>: SupportedLaneCount,
     T: SimdElement,
 {
+    /// Get the number of lanes in this vector.
+    pub const fn lanes(&self) -> usize {
+        LANES
+    }
+
     /// Construct a SIMD vector by setting all lanes to the given value.
     pub const fn splat(value: T) -> Self {
         Self([value; LANES])


### PR DESCRIPTION
Adds the lanes function for easily getting the number of lanes of a SIMD element

Fixes #151 