### PR TITLE
Renovate for Edition 2021

### DIFF
--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "core_simd"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/rust-lang/portable-simd"
 repository = "https://github.com/rust-lang/portable-simd"
 keywords = ["core", "simd", "intrinsics"]

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -11,6 +11,7 @@
 )]
 #![cfg_attr(feature = "generic_const_exprs", feature(generic_const_exprs))]
 #![warn(missing_docs)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "portable_simd", issue = "86656")]
 //! Portable SIMD module.
 

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -118,7 +118,7 @@ where
     /// All lanes must be either 0 or -1.
     #[inline]
     pub unsafe fn from_int_unchecked(value: Simd<T, LANES>) -> Self {
-        Self(mask_impl::Mask::from_int_unchecked(value))
+        unsafe { Self(mask_impl::Mask::from_int_unchecked(value)) }
     }
 
     /// Converts a vector of integers to a mask, where 0 represents `false` and -1
@@ -145,7 +145,7 @@ where
     /// `lane` must be less than `LANES`.
     #[inline]
     pub unsafe fn test_unchecked(&self, lane: usize) -> bool {
-        self.0.test_unchecked(lane)
+        unsafe { self.0.test_unchecked(lane) }
     }
 
     /// Tests the value of the specified lane.
@@ -164,7 +164,9 @@ where
     /// `lane` must be less than `LANES`.
     #[inline]
     pub unsafe fn set_unchecked(&mut self, lane: usize, value: bool) {
-        self.0.set_unchecked(lane, value);
+        unsafe {
+            self.0.set_unchecked(lane, value);
+        }
     }
 
     /// Sets the value of the specified lane.

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -93,7 +93,9 @@ where
 
     #[inline]
     pub unsafe fn set_unchecked(&mut self, lane: usize, value: bool) {
-        self.0.as_mut()[lane / 8] ^= ((value ^ self.test_unchecked(lane)) as u8) << (lane % 8)
+        unsafe {
+            self.0.as_mut()[lane / 8] ^= ((value ^ self.test_unchecked(lane)) as u8) << (lane % 8)
+        }
     }
 
     #[inline]
@@ -112,9 +114,11 @@ where
             core::mem::size_of::<<LaneCount::<LANES> as SupportedLaneCount>::BitMask>(),
             core::mem::size_of::<<LaneCount::<LANES> as SupportedLaneCount>::IntBitMask>(),
         );
-        let mask: <LaneCount<LANES> as SupportedLaneCount>::IntBitMask =
-            intrinsics::simd_bitmask(value);
-        Self(core::mem::transmute_copy(&mask), PhantomData)
+        unsafe {
+            let mask: <LaneCount<LANES> as SupportedLaneCount>::IntBitMask =
+                intrinsics::simd_bitmask(value);
+            Self(core::mem::transmute_copy(&mask), PhantomData)
+        }
     }
 
     #[cfg(feature = "generic_const_exprs")]

--- a/crates/core_simd/src/round.rs
+++ b/crates/core_simd/src/round.rs
@@ -61,7 +61,7 @@ macro_rules! implement {
             /// * Be representable in the return type, after truncating off its fractional part
             #[inline]
             pub unsafe fn to_int_unchecked(self) -> Simd<$int_type, LANES> {
-                intrinsics::simd_cast(self)
+                unsafe { intrinsics::simd_cast(self) }
             }
 
             /// Creates a floating-point vector from an integer vector.  Rounds values that are

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_helpers"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies.proptest]


### PR DESCRIPTION
In a still-future edition, `unsafe_op_in_unsafe_fn` may error.
Let's get ahead of that.