### PR TITLE
Restrict Arm types to Arm v7+

### DIFF
--- a/crates/core_simd/src/vendor.rs
+++ b/crates/core_simd/src/vendor.rs
@@ -20,7 +20,10 @@ mod x86;
 #[cfg(any(target_arch = "wasm32"))]
 mod wasm32;
 
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "aarch64",
+    all(target_arch = "arm", target_feature = "v7")
+))]
 mod arm;
 
 #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]

--- a/crates/core_simd/src/vendor/arm.rs
+++ b/crates/core_simd/src/vendor/arm.rs
@@ -1,6 +1,6 @@
 use crate::simd::*;
 
-#[cfg(target_arch = "arm")]
+#[cfg(all(target_arch = "arm", target_feature = "v7"))]
 use core::arch::arm::*;
 
 #[cfg(target_arch = "aarch64")]
@@ -35,7 +35,7 @@ from_transmute! { unsafe i64x2 => int64x2_t }
 from_transmute! { unsafe Simd<u64, 1> => poly64x1_t }
 from_transmute! { unsafe u64x2 => poly64x2_t }
 
-#[cfg(target_arch = "arm")]
+#[cfg(all(target_arch = "arm", target_feature = "v7"))]
 mod arm {
     use super::*;
     from_transmute! { unsafe Simd<u8, 4> => uint8x4_t }


### PR DESCRIPTION
This mostly mirrors the restrictions in std::arch.
It can be loosened slightly with later refactoring.