### PR TITLE
Introduce trait-driven arithmetic

### DIFF
--- a/crates/core_simd/src/math.rs
+++ b/crates/core_simd/src/math.rs
@@ -32,6 +32,7 @@ where
     /// assert_eq!(sat, Simd::from_array([-1, i32::MAX, i32::MAX, i32::MAX]));
     /// ```
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn saturating_add(self, other: Self) -> Self {
         unsafe { intrinsics::simd_saturating_add(self, other) }
     }
@@ -50,6 +51,7 @@ where
     /// assert_eq!(unsat, Simd::from_array([1, i32::MAX, i32::MIN, 0]));
     /// assert_eq!(sat, Simd::from_array([i32::MIN, i32::MIN, i32::MIN, 0]));
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn saturating_sub(self, other: Self) -> Self {
         unsafe { intrinsics::simd_saturating_sub(self, other) }
     }
@@ -121,6 +123,7 @@ where
     /// * `1` if the number is positive
     /// * `-1` if the number is negative
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn signum(self) -> Self {
         <Self as SimdSignum>::signum(self)
     }
@@ -150,6 +153,7 @@ where
     /// assert_eq!(xs.abs(), Simd::from_array([i32::MIN, i32::MAX, 5, 0]));
     /// ```
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn abs(self) -> Self {
         <Self as SimdAbs>::abs(self)
     }

--- a/crates/core_simd/src/mod.rs
+++ b/crates/core_simd/src/mod.rs
@@ -5,6 +5,7 @@ mod reduction;
 mod swizzle;
 
 pub(crate) mod intrinsics;
+pub(crate) mod math;
 
 #[cfg(feature = "generic_const_exprs")]
 mod to_bytes;
@@ -14,7 +15,6 @@ mod fmt;
 mod iter;
 mod lane_count;
 mod masks;
-mod math;
 mod ops;
 mod round;
 mod select;
@@ -24,6 +24,7 @@ mod vendor;
 #[doc = include_str!("core_simd_docs.md")]
 pub mod simd {
     pub(crate) use crate::core_simd::intrinsics;
+    pub(crate) use crate::core_simd::math::*;
 
     pub use crate::core_simd::lane_count::{LaneCount, SupportedLaneCount};
     pub use crate::core_simd::masks::*;

--- a/crates/core_simd/src/ops.rs
+++ b/crates/core_simd/src/ops.rs
@@ -174,9 +174,9 @@ macro_rules! impl_op {
     { impl Shl for $scalar:ty } => {
         impl_op! { @binary $scalar, Shl::shl, ShlAssign::shl_assign, simd_shl }
     };
-    { impl Shr for $scalar:ty } => {
-        impl_op! { @binary $scalar, Shr::shr, ShrAssign::shr_assign, simd_shr }
-    };
+    // { impl Shr for $scalar:ty } => {
+    //     impl_op! { @binary $scalar, Shr::shr, ShrAssign::shr_assign, simd_shr }
+    // };
     { impl BitAnd for $scalar:ty } => {
         impl_op! { @binary $scalar, BitAnd::bitand, BitAndAssign::bitand_assign, simd_and }
     };
@@ -561,70 +561,70 @@ macro_rules! impl_unsigned_int_ops {
                 }
             }
 
-            impl_ref_ops! {
-                impl<const LANES: usize> core::ops::Shr<Self> for Simd<$scalar, LANES>
-                where
-                    LaneCount<LANES>: SupportedLaneCount,
-                {
-                    type Output = Self;
+            // impl_ref_ops! {
+            //     impl<const LANES: usize> core::ops::Shr<Self> for Simd<$scalar, LANES>
+            //     where
+            //         LaneCount<LANES>: SupportedLaneCount,
+            //     {
+            //         type Output = Self;
 
-                    #[inline]
-                    fn shr(self, rhs: Self) -> Self::Output {
-                        // TODO there is probably a better way of doing this
-                        if rhs.as_array()
-                            .iter()
-                            .copied()
-                            .any(invalid_shift_rhs)
-                        {
-                            panic!("attempt to shift with overflow");
-                        }
-                        unsafe { intrinsics::simd_shr(self, rhs) }
-                    }
-                }
-            }
+            //         #[inline]
+            //         fn shr(self, rhs: Self) -> Self::Output {
+            //             // TODO there is probably a better way of doing this
+            //             if rhs.as_array()
+            //                 .iter()
+            //                 .copied()
+            //                 .any(invalid_shift_rhs)
+            //             {
+            //                 panic!("attempt to shift with overflow");
+            //             }
+            //             unsafe { intrinsics::simd_shr(self, rhs) }
+            //         }
+            //     }
+            // }
 
-            impl_ref_ops! {
-                impl<const LANES: usize> core::ops::Shr<$scalar> for Simd<$scalar, LANES>
-                where
-                    LaneCount<LANES>: SupportedLaneCount,
-                {
-                    type Output = Self;
+            // impl_ref_ops! {
+            //     impl<const LANES: usize> core::ops::Shr<$scalar> for Simd<$scalar, LANES>
+            //     where
+            //         LaneCount<LANES>: SupportedLaneCount,
+            //     {
+            //         type Output = Self;
 
-                    #[inline]
-                    fn shr(self, rhs: $scalar) -> Self::Output {
-                        if invalid_shift_rhs(rhs) {
-                            panic!("attempt to shift with overflow");
-                        }
-                        let rhs = Self::splat(rhs);
-                        unsafe { intrinsics::simd_shr(self, rhs) }
-                    }
-                }
-            }
+            //         #[inline]
+            //         fn shr(self, rhs: $scalar) -> Self::Output {
+            //             if invalid_shift_rhs(rhs) {
+            //                 panic!("attempt to shift with overflow");
+            //             }
+            //             let rhs = Self::splat(rhs);
+            //             unsafe { intrinsics::simd_shr(self, rhs) }
+            //         }
+            //     }
+            // }
 
 
-            impl_ref_ops! {
-                impl<const LANES: usize> core::ops::ShrAssign<Self> for Simd<$scalar, LANES>
-                where
-                    LaneCount<LANES>: SupportedLaneCount,
-                {
-                    #[inline]
-                    fn shr_assign(&mut self, rhs: Self) {
-                        *self = *self >> rhs;
-                    }
-                }
-            }
+            // impl_ref_ops! {
+            //     impl<const LANES: usize> core::ops::ShrAssign<Self> for Simd<$scalar, LANES>
+            //     where
+            //         LaneCount<LANES>: SupportedLaneCount,
+            //     {
+            //         #[inline]
+            //         fn shr_assign(&mut self, rhs: Self) {
+            //             *self = *self >> rhs;
+            //         }
+            //     }
+            // }
 
-            impl_ref_ops! {
-                impl<const LANES: usize> core::ops::ShrAssign<$scalar> for Simd<$scalar, LANES>
-                where
-                    LaneCount<LANES>: SupportedLaneCount,
-                {
-                    #[inline]
-                    fn shr_assign(&mut self, rhs: $scalar) {
-                        *self = *self >> rhs;
-                    }
-                }
-            }
+            // impl_ref_ops! {
+            //     impl<const LANES: usize> core::ops::ShrAssign<$scalar> for Simd<$scalar, LANES>
+            //     where
+            //         LaneCount<LANES>: SupportedLaneCount,
+            //     {
+            //         #[inline]
+            //         fn shr_assign(&mut self, rhs: $scalar) {
+            //             *self = *self >> rhs;
+            //         }
+            //     }
+            // }
         )*
     };
 }

--- a/crates/core_simd/src/reduction.rs
+++ b/crates/core_simd/src/reduction.rs
@@ -12,6 +12,7 @@ where
     /// Horizontal bitwise "and".  Returns the cumulative bitwise "and" across the lanes of
     /// the vector.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_and(self) -> T {
         unsafe { simd_reduce_and(self) }
     }
@@ -19,6 +20,7 @@ where
     /// Horizontal bitwise "or".  Returns the cumulative bitwise "or" across the lanes of
     /// the vector.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_or(self) -> T {
         unsafe { simd_reduce_or(self) }
     }
@@ -26,6 +28,7 @@ where
     /// Horizontal bitwise "xor".  Returns the cumulative bitwise "xor" across the lanes of
     /// the vector.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_xor(self) -> T {
         unsafe { simd_reduce_xor(self) }
     }
@@ -41,6 +44,7 @@ where
     /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
     /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_max(self) -> T {
         unsafe { simd_reduce_max(self) }
     }
@@ -50,6 +54,7 @@ where
     /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
     /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_min(self) -> T {
         unsafe { simd_reduce_min(self) }
     }
@@ -63,12 +68,14 @@ where
 {
     /// Horizontal add.  Returns the sum of the lanes of the vector.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_sum(self) -> T {
         <Self as HorizontalArith>::horizontal_sum(self)
     }
 
     /// Horizontal multiply.  Returns the product of the lanes of the vector.
     #[inline]
+    #[must_use = "method returns a new value and does not mutate the original vector"]
     pub fn horizontal_product(self) -> T {
         <Self as HorizontalArith>::horizontal_product(self)
     }

--- a/crates/core_simd/src/reduction.rs
+++ b/crates/core_simd/src/reduction.rs
@@ -2,57 +2,116 @@ use crate::simd::intrinsics::{
     simd_reduce_add_ordered, simd_reduce_and, simd_reduce_max, simd_reduce_min,
     simd_reduce_mul_ordered, simd_reduce_or, simd_reduce_xor,
 };
-use crate::simd::{LaneCount, Simd, SupportedLaneCount};
+use crate::simd::{Int, LaneCount, Simd, SimdElement, SupportedLaneCount};
+
+impl<T, const LANES: usize> Simd<T, LANES>
+where
+    T: Int,
+    LaneCount<LANES>: SupportedLaneCount,
+{
+    /// Horizontal bitwise "and".  Returns the cumulative bitwise "and" across the lanes of
+    /// the vector.
+    #[inline]
+    pub fn horizontal_and(self) -> T {
+        unsafe { simd_reduce_and(self) }
+    }
+
+    /// Horizontal bitwise "or".  Returns the cumulative bitwise "or" across the lanes of
+    /// the vector.
+    #[inline]
+    pub fn horizontal_or(self) -> T {
+        unsafe { simd_reduce_or(self) }
+    }
+
+    /// Horizontal bitwise "xor".  Returns the cumulative bitwise "xor" across the lanes of
+    /// the vector.
+    #[inline]
+    pub fn horizontal_xor(self) -> T {
+        unsafe { simd_reduce_xor(self) }
+    }
+}
+
+impl<T, const LANES: usize> Simd<T, LANES>
+where
+    T: SimdElement,
+    LaneCount<LANES>: SupportedLaneCount,
+{
+    /// Horizontal maximum.  Returns the maximum lane in the vector.
+    ///
+    /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
+    /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
+    #[inline]
+    pub fn horizontal_max(self) -> T {
+        unsafe { simd_reduce_max(self) }
+    }
+
+    /// Horizontal minimum.  Returns the minimum lane in the vector.
+    ///
+    /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
+    /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
+    #[inline]
+    pub fn horizontal_min(self) -> T {
+        unsafe { simd_reduce_min(self) }
+    }
+}
+
+impl<T, const LANES: usize> Simd<T, LANES>
+where
+    Self: HorizontalArith<Scalar = T>,
+    T: SimdElement,
+    LaneCount<LANES>: SupportedLaneCount,
+{
+    /// Horizontal add.  Returns the sum of the lanes of the vector.
+    #[inline]
+    pub fn horizontal_sum(self) -> T {
+        <Self as HorizontalArith>::horizontal_sum(self)
+    }
+
+    /// Horizontal multiply.  Returns the product of the lanes of the vector.
+    #[inline]
+    pub fn horizontal_product(self) -> T {
+        <Self as HorizontalArith>::horizontal_product(self)
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+use sealed::Sealed;
+impl<T, const LANES: usize> Sealed for Simd<T, LANES>
+where
+    T: SimdElement,
+    LaneCount<LANES>: SupportedLaneCount,
+{
+}
+
+pub trait HorizontalArith: Sealed {
+    type Scalar: SimdElement;
+    /// Horizontal add.  Returns the sum of the lanes of the vector.
+    fn horizontal_sum(self) -> Self::Scalar;
+
+    /// Horizontal multiply.  Returns the product of the lanes of the vector.
+    fn horizontal_product(self) -> Self::Scalar;
+}
 
 macro_rules! impl_integer_reductions {
     { $scalar:ty } => {
-        impl<const LANES: usize> Simd<$scalar, LANES>
+        impl<const LANES: usize> HorizontalArith for Simd<$scalar, LANES>
         where
-            LaneCount<LANES>: SupportedLaneCount,
-        {
+        LaneCount<LANES>: SupportedLaneCount,
+
+{
+            type Scalar = $scalar;
             /// Horizontal wrapping add.  Returns the sum of the lanes of the vector, with wrapping addition.
             #[inline]
-            pub fn horizontal_sum(self) -> $scalar {
+            fn horizontal_sum(self) -> $scalar {
                 unsafe { simd_reduce_add_ordered(self, 0) }
             }
 
             /// Horizontal wrapping multiply.  Returns the product of the lanes of the vector, with wrapping multiplication.
             #[inline]
-            pub fn horizontal_product(self) -> $scalar {
+            fn horizontal_product(self) -> $scalar {
                 unsafe { simd_reduce_mul_ordered(self, 1) }
-            }
-
-            /// Horizontal bitwise "and".  Returns the cumulative bitwise "and" across the lanes of
-            /// the vector.
-            #[inline]
-            pub fn horizontal_and(self) -> $scalar {
-                unsafe { simd_reduce_and(self) }
-            }
-
-            /// Horizontal bitwise "or".  Returns the cumulative bitwise "or" across the lanes of
-            /// the vector.
-            #[inline]
-            pub fn horizontal_or(self) -> $scalar {
-                unsafe { simd_reduce_or(self) }
-            }
-
-            /// Horizontal bitwise "xor".  Returns the cumulative bitwise "xor" across the lanes of
-            /// the vector.
-            #[inline]
-            pub fn horizontal_xor(self) -> $scalar {
-                unsafe { simd_reduce_xor(self) }
-            }
-
-            /// Horizontal maximum.  Returns the maximum lane in the vector.
-            #[inline]
-            pub fn horizontal_max(self) -> $scalar {
-                unsafe { simd_reduce_max(self) }
-            }
-
-            /// Horizontal minimum.  Returns the minimum lane in the vector.
-            #[inline]
-            pub fn horizontal_min(self) -> $scalar {
-                unsafe { simd_reduce_min(self) }
             }
         }
     }
@@ -71,14 +130,16 @@ impl_integer_reductions! { usize }
 
 macro_rules! impl_float_reductions {
     { $scalar:ty } => {
-        impl<const LANES: usize> Simd<$scalar, LANES>
+        impl<const LANES: usize> HorizontalArith for Simd<$scalar, LANES>
         where
-            LaneCount<LANES>: SupportedLaneCount,
-        {
+        LaneCount<LANES>: SupportedLaneCount,
+
+{
+            type Scalar = $scalar;
 
             /// Horizontal add.  Returns the sum of the lanes of the vector.
             #[inline]
-            pub fn horizontal_sum(self) -> $scalar {
+            fn horizontal_sum(self) -> $scalar {
                 // LLVM sum is inaccurate on i586
                 if cfg!(all(target_arch = "x86", not(target_feature = "sse2"))) {
                     self.as_array().iter().sum()
@@ -89,31 +150,13 @@ macro_rules! impl_float_reductions {
 
             /// Horizontal multiply.  Returns the product of the lanes of the vector.
             #[inline]
-            pub fn horizontal_product(self) -> $scalar {
+            fn horizontal_product(self) -> $scalar {
                 // LLVM product is inaccurate on i586
                 if cfg!(all(target_arch = "x86", not(target_feature = "sse2"))) {
                     self.as_array().iter().product()
                 } else {
                     unsafe { simd_reduce_mul_ordered(self, 1.) }
                 }
-            }
-
-            /// Horizontal maximum.  Returns the maximum lane in the vector.
-            ///
-            /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
-            /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
-            #[inline]
-            pub fn horizontal_max(self) -> $scalar {
-                unsafe { simd_reduce_max(self) }
-            }
-
-            /// Horizontal minimum.  Returns the minimum lane in the vector.
-            ///
-            /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
-            /// return either.  This function will not return `NaN` unless all lanes are `NaN`.
-            #[inline]
-            pub fn horizontal_min(self) -> $scalar {
-                unsafe { simd_reduce_min(self) }
             }
         }
     }

--- a/crates/core_simd/src/vector/int.rs
+++ b/crates/core_simd/src/vector/int.rs
@@ -18,6 +18,7 @@ where
 
     /// Returns true for each negative lane and false if it is zero or positive.
     #[inline]
+    #[must_use = "method returns a new mask and does not mutate the original value"]
     pub fn is_negative(self) -> Mask<T::Mask, LANES> {
         self.lanes_lt(Self::default())
     }
@@ -37,6 +38,7 @@ where
     /// assert_eq!(sat, Simd::from_array([i32::MAX, 2, 0, 3]));
     /// ```
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn saturating_abs(self) -> Self {
         // arith shift for -1 or 0 mask based on sign bit, giving 2s complement
         let shr = T::BITS - 1;
@@ -59,6 +61,7 @@ where
     /// assert_eq!(sat, Simd::from_array([i32::MAX, 2, -3, i32::MIN + 1]));
     /// ```
     #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn saturating_neg(self) -> Self {
         Self::default().saturating_sub(self)
     }

--- a/crates/core_simd/src/vector/uint.rs
+++ b/crates/core_simd/src/vector/uint.rs
@@ -1,5 +1,4 @@
 #![allow(non_camel_case_types)]
-
 use crate::simd::Simd;
 
 /// Vector of two `usize` values


### PR DESCRIPTION
This allows collapsing 5~10 instances of a function on the Simd type
into 1-3 copies, at least from the perspective of the docs.
The result is far more legible to a user.

Left deliberately unfinished to offer a taste of the difference
and allow the comparative angles to be discussed.
