### PR TITLE
Attempt to support to 64 lanes

### DIFF
--- a/crates/core_simd/src/lane_count.rs
+++ b/crates/core_simd/src/lane_count.rs
@@ -37,3 +37,6 @@ impl SupportedLaneCount for LaneCount<16> {
 impl SupportedLaneCount for LaneCount<32> {
     type BitMask = [u8; 4];
 }
+impl SupportedLaneCount for LaneCount<64> {
+    type BitMask = [u8; 8];
+}

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -376,6 +376,12 @@ macro_rules! test_lanes {
                 fn lanes_32() {
                     implementation::<32>();
                 }
+
+                #[test]
+                #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+                fn lanes_64() {
+                    implementation::<64>();
+                }
             }
         )*
     }
@@ -430,6 +436,12 @@ macro_rules! test_lanes_panic {
                 #[should_panic]
                 fn lanes_32() {
                     implementation::<32>();
+                }
+
+                #[test]
+                #[should_panic]
+                fn lanes_64() {
+                    implementation::<64>();
                 }
             }
         )*


### PR DESCRIPTION
We can try to expand our support, and test suite, to allow `Simd<T, 64>`.