### PR TITLE
Remove Select trait

### DIFF
--- a/crates/core_simd/src/mod.rs
+++ b/crates/core_simd/src/mod.rs
@@ -27,7 +27,6 @@ pub mod simd {
 
     pub use crate::core_simd::lane_count::{LaneCount, SupportedLaneCount};
     pub use crate::core_simd::masks::*;
-    pub use crate::core_simd::select::Select;
     pub use crate::core_simd::swizzle::*;
     pub use crate::core_simd::vector::*;
 }


### PR DESCRIPTION
I realized that our `select` implementation predated `Simd` being generic over element type, and we don't really need the `Select` trait at all.  The function signature is much simpler now (generic over element type, rather than over the entire vector).  This did require changing mask select to be a different function, but I think that's fine considering they're not necessarily vectors.