### PR TITLE
Enable scatters with `&mut [MaybeUninit<T>]`

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -1,12 +1,19 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(
-    const_fn_trait_bound,
-    decl_macro,
+#![feature( // rustc internals
     platform_intrinsics,
     repr_simd,
-    simd_ffi,
     staged_api,
-    stdsimd
+)]
+#![feature( // lang features
+    const_fn_trait_bound,
+    decl_macro,
+    simd_ffi,
+)]
+#![feature( // library features
+    maybe_uninit_slice,
+    maybe_uninit_array_assume_init,
+    maybe_uninit_uninit_array,
+    stdsimd,
 )]
 #![cfg_attr(feature = "generic_const_exprs", feature(generic_const_exprs))]
 #![cfg_attr(feature = "generic_const_exprs", allow(incomplete_features))]


### PR DESCRIPTION
This PR makes `unsafe fn scatter_select_unchecked` more unsafe, by allowing it to accept a raw `*mut T`, and thus exposing all the invariants underneath the previous function but also allowing more uses. It then adds `scatter_uninit` as a variant on `scatter_select`, for the safe scatter to `&mut [MaybeUninit<T>]`.

This closes rust-lang/portable-simd#205.