### PR TITLE
fix documentation typo

### DIFF
--- a/crates/core_simd/src/vector/float.rs
+++ b/crates/core_simd/src/vector/float.rs
@@ -106,7 +106,7 @@ macro_rules! impl_float_vector {
             }
 
             /// Returns true for each lane if its value is neither zero, infinite,
-            /// subnormal, or `NaN`.
+            /// subnormal, nor `NaN`.
             #[inline]
             #[must_use = "method returns a new mask and does not mutate the original value"]
             pub fn is_normal(self) -> Mask<$mask_ty, LANES> {

--- a/crates/core_simd/src/vector/float.rs
+++ b/crates/core_simd/src/vector/float.rs
@@ -105,7 +105,7 @@ macro_rules! impl_float_vector {
                 self.abs().lanes_ne(Self::splat(0.0)) & (self.to_bits() & Self::splat(<$type>::INFINITY).to_bits()).lanes_eq(Simd::splat(0))
             }
 
-            /// Returns true for each lane if its value is neither neither zero, infinite,
+            /// Returns true for each lane if its value is neither zero, infinite,
             /// subnormal, or `NaN`.
             #[inline]
             #[must_use = "method returns a new mask and does not mutate the original value"]


### PR DESCRIPTION
Remove redundant "neither" in the documentation comment.
