### PR TITLE
Omit Simd::cast during bootstrap

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -41,6 +41,7 @@ extern "platform-intrinsic" {
     pub(crate) fn simd_cast<T, U>(x: T) -> U;
     /// follows Rust's `T as U` semantics, including saturating float casts
     /// which amounts to the same as `simd_cast` for many cases
+    #[cfg(not(bootstrap))]
     pub(crate) fn simd_as<T, U>(x: T) -> U;
 
     /// neg/fneg

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -100,6 +100,7 @@ where
     /// ```
     #[must_use]
     #[inline]
+    #[cfg(not(bootstrap))]
     pub fn cast<U: SimdElement>(self) -> Simd<U, LANES> {
         unsafe { intrinsics::simd_as(self) }
     }


### PR DESCRIPTION
Since the `simd_as` intrinsic was recently added and the bootstrap compiler is the beta compiler, it can't bootstrap successfully unless we omit `core::simd` from bootstrap. But that's starting to be inconvenient, and `Simd::cast` isn't deeply meshed into our API, so we can just omit it.