### PR TITLE
Remove default features

### DIFF
--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["std", "generic_const_exprs"]
+default = []
 std = []
 generic_const_exprs = []
 

--- a/crates/core_simd/tests/round.rs
+++ b/crates/core_simd/tests/round.rs
@@ -2,6 +2,7 @@
 
 macro_rules! float_rounding_test {
     { $scalar:tt, $int_scalar:tt } => {
+        #[cfg(feature = "std")]
         mod $scalar {
             use std_float::StdFloat;
 

--- a/crates/core_simd/tests/round.rs
+++ b/crates/core_simd/tests/round.rs
@@ -2,7 +2,6 @@
 
 macro_rules! float_rounding_test {
     { $scalar:tt, $int_scalar:tt } => {
-        #[cfg(feature = "std")]
         mod $scalar {
             use std_float::StdFloat;
 
@@ -10,7 +9,6 @@ macro_rules! float_rounding_test {
             type Scalar = $scalar;
             type IntScalar = $int_scalar;
 
-            #[cfg(feature = "std")]
             test_helpers::test_lanes! {
                 fn ceil<const LANES: usize>() {
                     test_helpers::test_unary_elementwise(

--- a/crates/std_float/Cargo.toml
+++ b/crates/std_float/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-core_simd = { path = "../core_simd" }
+core_simd = { path = "../core_simd", default-features = false }
 
 [features]
 default = ["as_crate"]


### PR DESCRIPTION
Now that we are thoroughly embedded in libcore, we don't need these on by default.
Indeed, their presence may provide confusing results during integration attempts.