### PR TITLE
Add Mask::cast

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -181,6 +181,13 @@ where
         self.0.to_int()
     }
 
+    /// Converts the mask to a mask of any other lane size.
+    #[inline]
+    #[must_use = "method returns a new mask and does not mutate the original value"]
+    pub fn cast<U: MaskElement>(self) -> Mask<U, LANES> {
+        Mask(self.0.convert())
+    }
+
     /// Tests the value of the specified lane.
     ///
     /// # Safety

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -578,7 +578,7 @@ macro_rules! impl_from {
             LaneCount<LANES>: SupportedLaneCount,
         {
             fn from(value: Mask<$from, LANES>) -> Self {
-                Self(value.0.convert())
+                value.cast()
             }
         }
         )*

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -99,6 +99,29 @@ macro_rules! test_mask_api {
                 assert_eq!(bitmask, 0b01);
                 assert_eq!(core_simd::Mask::<$type, 2>::from_bitmask(bitmask), mask);
             }
+
+            #[test]
+            fn cast() {
+                fn cast_impl<T: core_simd::MaskElement>()
+                where
+                    core_simd::Mask<$type, 8>: Into<core_simd::Mask<T, 8>>,
+                {
+                    let values = [true, false, false, true, false, false, true, false];
+                    let mask = core_simd::Mask::<$type, 8>::from_array(values);
+
+                    let cast_mask = mask.cast::<T>();
+                    assert_eq!(values, cast_mask.to_array());
+
+                    let into_mask: core_simd::Mask<T, 8> = mask.into();
+                    assert_eq!(values, into_mask.to_array());
+                }
+
+                cast_impl::<i8>();
+                cast_impl::<i16>();
+                cast_impl::<i32>();
+                cast_impl::<i64>();
+                cast_impl::<isize>();
+            }
         }
     }
 }


### PR DESCRIPTION
Requested. Users are taking surprisingly generic tacks here so this seems warranted, even if it may or may not optimize well. Unfortunately, we can't simply just implement `From` in a way that yields this naturally because of the following conflict:

<pre><b>error[E0119]: conflicting implementations
of trait `core::convert::From&lt;core_simd::masks::Mask&lt;_, {_: usize}&gt;&gt;`
for type `core_simd::masks::Mask&lt;_, {_: usize}&gt;`</b>
   <b>--&gt; </b>crates/core_simd/src/masks.rs:579:1
    <b>|</b>
<b>579| /</b> impl&lt;T, U, const N: usize&gt; From&lt;Mask&lt;T, N&gt;&gt; for Mask&lt;U, N&gt;
<b>580| |</b> where
<b>581| |</b>     LaneCount&lt;N&gt;: SupportedLaneCount,
<b>582| |</b> {
<b>...|</b>
<b>585| |</b>     }
<b>586| |</b> }
    <b>| |_^</b>
    <b>|</b>
    <b>= note</b>: conflicting implementation in crate `core`:
            - impl&lt;T&gt; From&lt;T&gt; for T;

<b>For more information about this error, try `rustc --explain E0119`.</b>
<b>error:</b> could not compile `core_simd` due to previous error
</pre>