### PR TITLE
extern blocks don't have doc comments

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -18,9 +18,9 @@
 //!
 //! Unless stated otherwise, all intrinsics for binary operations require SIMD vectors of equal types and lengths.
 
-/// These intrinsics aren't linked directly from LLVM and are mostly undocumented, however they are
-/// mostly lowered to the matching LLVM instructions by the compiler in a fairly straightforward manner.
-/// The associated LLVM instruction or intrinsic is documented alongside each Rust intrinsic function.
+// These intrinsics aren't linked directly from LLVM and are mostly undocumented, however they are
+// mostly lowered to the matching LLVM instructions by the compiler in a fairly straightforward manner.
+// The associated LLVM instruction or intrinsic is documented alongside each Rust intrinsic function.
 extern "platform-intrinsic" {
     /// add/fadd
     pub(crate) fn simd_add<T>(x: T, y: T) -> T;


### PR DESCRIPTION
Fixes a warning I see when building this code:
```
warning: unused doc comment
   --> crates/core_simd/src/intrinsics.rs:21:1
    |
21  | / /// These intrinsics aren't linked directly from LLVM and are mostly undocumented, however they are
22  | | /// mostly lowered to the matching LLVM instructions by the compiler in a fairly straightforward manner.
23  | | /// The associated LLVM instruction or intrinsic is documented alongside each Rust intrinsic function.
    | |______________________________________________________________________________________________________^
24  | / extern "platform-intrinsic" {
25  | |     /// add/fadd
26  | |     pub(crate) fn simd_add<T>(x: T, y: T) -> T;
27  | |
...   |
150 | |     pub(crate) fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
151 | | }
    | |_- rustdoc does not generate documentation for extern block
    |
    = note: `#[warn(unused_doc_comments)]` on by default
    = help: use `//` for a plain comment
```