### PR TITLE
Use SIMD equality for PartialEq on SIMD vectors

### DIFF
--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -429,8 +429,26 @@ where
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        // TODO use SIMD equality
-        self.to_array() == other.to_array()
+        // Safety: All SIMD vectors are SimdPartialEq, and the comparison produces a valid mask.
+        let mask = unsafe {
+            let tfvec: Simd<<T as SimdElement>::Mask, LANES> = intrinsics::simd_eq(*self, *other);
+            Mask::from_int_unchecked(tfvec)
+        };
+
+        // Two vectors are equal if all lanes tested true for vertical equality.
+        mask.all()
+    }
+
+    #[inline]
+    fn ne(&self, other: &Self) -> bool {
+        // Safety: All SIMD vectors are SimdPartialEq, and the comparison produces a valid mask.
+        let mask = unsafe {
+            let tfvec: Simd<<T as SimdElement>::Mask, LANES> = intrinsics::simd_ne(*self, *other);
+            Mask::from_int_unchecked(tfvec)
+        };
+
+        // Two vectors are non-equal if any lane tested true for vertical non-equality.
+        mask.any()
     }
 }
 


### PR DESCRIPTION
A small change implementing parallel `PartialEq` for `Simd` vectors, fixing a `TODO`. All `Simd` vectors by definition support `SimdPartialEq`, so the logic is copied.

I currently think that the call to `simd_reduce_all` should indeed be round-tripped through `Mask` to produce a proper integer vector, to handle odd architectures. I wasn't sure if `simd_reduce_all(simd_eq(x, y))` was valid, in particular because the definition in LLVM appears to be bitwise AND, and I wasn't clear on where the reduction to Rust `bool` takes place.