### PR TITLE
Strengthen warnings about relying on Mask layout

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -83,7 +83,9 @@ impl_element! { isize }
 ///
 /// Masks represent boolean inclusion/exclusion on a per-lane basis.
 ///
-/// The layout of this type is unspecified.
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[T; LANES]`.
 #[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where
@@ -521,57 +523,129 @@ where
 }
 
 /// A mask for SIMD vectors with eight elements of 8 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i8; 8]`.
 pub type mask8x8 = Mask<i8, 8>;
 
 /// A mask for SIMD vectors with 16 elements of 8 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i8; 16]`.
 pub type mask8x16 = Mask<i8, 16>;
 
 /// A mask for SIMD vectors with 32 elements of 8 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i8; 32]`.
 pub type mask8x32 = Mask<i8, 32>;
 
 /// A mask for SIMD vectors with 64 elements of 8 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i8; 64]`.
 pub type mask8x64 = Mask<i8, 64>;
 
 /// A mask for SIMD vectors with four elements of 16 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i16; 4]`.
 pub type mask16x4 = Mask<i16, 4>;
 
 /// A mask for SIMD vectors with eight elements of 16 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i16; 8]`.
 pub type mask16x8 = Mask<i16, 8>;
 
 /// A mask for SIMD vectors with 16 elements of 16 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i16; 16]`.
 pub type mask16x16 = Mask<i16, 16>;
 
 /// A mask for SIMD vectors with 32 elements of 16 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i16; 32]`.
 pub type mask16x32 = Mask<i16, 32>;
 
 /// A mask for SIMD vectors with two elements of 32 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i32; 2]`.
 pub type mask32x2 = Mask<i32, 2>;
 
 /// A mask for SIMD vectors with four elements of 32 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i32; 4]`.
 pub type mask32x4 = Mask<i32, 4>;
 
 /// A mask for SIMD vectors with eight elements of 32 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i32; 8]`.
 pub type mask32x8 = Mask<i32, 8>;
 
 /// A mask for SIMD vectors with 16 elements of 32 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i32; 16]`.
 pub type mask32x16 = Mask<i32, 16>;
 
 /// A mask for SIMD vectors with two elements of 64 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i64; 2]`.
 pub type mask64x2 = Mask<i64, 2>;
 
 /// A mask for SIMD vectors with four elements of 64 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i64; 4]`.
 pub type mask64x4 = Mask<i64, 4>;
 
 /// A mask for SIMD vectors with eight elements of 64 bits.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[i64; 8]`.
 pub type mask64x8 = Mask<i64, 8>;
 
 /// A mask for SIMD vectors with two elements of pointer width.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[isize; 2]`.
 pub type masksizex2 = Mask<isize, 2>;
 
 /// A mask for SIMD vectors with four elements of pointer width.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[isize; 4]`.
 pub type masksizex4 = Mask<isize, 4>;
 
 /// A mask for SIMD vectors with eight elements of pointer width.
+///
+/// The layout of this type is unspecified, and may change between platforms
+/// and/or Rust versions, and code should not assume that it is equivalent to
+/// `[isize; 8]`.
 pub type masksizex8 = Mask<isize, 8>;
 
 macro_rules! impl_from {


### PR DESCRIPTION
This makes it more clear that you can't rely on the layout of these, which seems worth doing given that the names vaguely suggest that you can (and the docs only clarify that you can't on `Mask` but not the `maskNxM` aliases).

Not tied to the specific wording here, and I'm not sure that it's actually worth clarifying that "yes, this includes `[iN; M]`", so I'm open to rewording. I do think we should have the caveat on the type aliases as well, though.