### PR TITLE
Add missing pointer tests and rename pointer cast fns to match scalars

### DIFF
--- a/crates/core_simd/src/elements/const_ptr.rs
+++ b/crates/core_simd/src/elements/const_ptr.rs
@@ -19,7 +19,9 @@ pub trait SimdConstPtr: Copy + Sealed {
     fn is_null(self) -> Self::Mask;
 
     /// Changes constness without changing the type.
-    fn as_mut(self) -> Self::MutPtr;
+    ///
+    /// Equivalent to calling [`pointer::cast_mut`] on each lane.
+    fn cast_mut(self) -> Self::MutPtr;
 
     /// Gets the "address" portion of the pointer.
     ///
@@ -85,7 +87,7 @@ where
     }
 
     #[inline]
-    fn as_mut(self) -> Self::MutPtr {
+    fn cast_mut(self) -> Self::MutPtr {
         self.cast_ptr()
     }
 

--- a/crates/core_simd/src/elements/mut_ptr.rs
+++ b/crates/core_simd/src/elements/mut_ptr.rs
@@ -19,7 +19,9 @@ pub trait SimdMutPtr: Copy + Sealed {
     fn is_null(self) -> Self::Mask;
 
     /// Changes constness without changing the type.
-    fn as_const(self) -> Self::ConstPtr;
+    ///
+    /// Equivalent to calling [`pointer::cast_const`] on each lane.
+    fn cast_const(self) -> Self::ConstPtr;
 
     /// Gets the "address" portion of the pointer.
     ///
@@ -80,7 +82,7 @@ where
     }
 
     #[inline]
-    fn as_const(self) -> Self::ConstPtr {
+    fn cast_const(self) -> Self::ConstPtr {
         self.cast_ptr()
     }
 

--- a/crates/core_simd/tests/pointers.rs
+++ b/crates/core_simd/tests/pointers.rs
@@ -21,6 +21,22 @@ macro_rules! common_tests {
                 );
             }
 
+            fn with_addr<const LANES: usize>() {
+                test_helpers::test_binary_elementwise(
+                    &Simd::<*$constness u32, LANES>::with_addr,
+                    &<*$constness u32>::with_addr,
+                    &|_, _| true,
+                );
+            }
+
+            fn expose_addr<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &Simd::<*$constness u32, LANES>::expose_addr,
+                    &<*$constness u32>::expose_addr,
+                    &|_| true,
+                );
+            }
+
             fn wrapping_offset<const LANES: usize>() {
                 test_helpers::test_binary_elementwise(
                     &Simd::<*$constness u32, LANES>::wrapping_offset,
@@ -51,9 +67,45 @@ macro_rules! common_tests {
 mod const_ptr {
     use super::*;
     common_tests! { const }
+
+    test_helpers::test_lanes! {
+        fn cast_mut<const LANES: usize>() {
+            test_helpers::test_unary_elementwise(
+                &Simd::<*const u32, LANES>::cast_mut,
+                &<*const u32>::cast_mut,
+                &|_| true,
+            );
+        }
+
+        fn from_exposed_addr<const LANES: usize>() {
+            test_helpers::test_unary_elementwise(
+                &Simd::<*const u32, LANES>::from_exposed_addr,
+                &core::ptr::from_exposed_addr::<u32>,
+                &|_| true,
+            );
+        }
+    }
 }
 
 mod mut_ptr {
     use super::*;
     common_tests! { mut }
+
+    test_helpers::test_lanes! {
+        fn cast_const<const LANES: usize>() {
+            test_helpers::test_unary_elementwise(
+                &Simd::<*mut u32, LANES>::cast_const,
+                &<*mut u32>::cast_const,
+                &|_| true,
+            );
+        }
+
+        fn from_exposed_addr<const LANES: usize>() {
+            test_helpers::test_unary_elementwise(
+                &Simd::<*mut u32, LANES>::from_exposed_addr,
+                &core::ptr::from_exposed_addr_mut::<u32>,
+                &|_| true,
+            );
+        }
+    }
 }


### PR DESCRIPTION
Adding some missing tests as mentioned: https://github.com/rust-lang/portable-simd/pull/287#pullrequestreview-1168080308

Also, renamed `as_mut`/`as_const` to `cast_mut`/`cast_const` (the names must have changed in `std` before stabilization)