### PR TITLE
Avoid a scalar loop in `Simd::from_slice`

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![feature(
+    const_ptr_read,
     convert_float_to_int,
     decl_macro,
     intra_doc_pointers,

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -174,13 +174,10 @@ where
             slice.len() >= LANES,
             "slice length must be at least the number of lanes"
         );
-        let mut array = [slice[0]; LANES];
-        let mut i = 0;
-        while i < LANES {
-            array[i] = slice[i];
-            i += 1;
-        }
-        Self(array)
+        // Safety:
+        // - We've checked the length is sufficient.
+        // - `T` and `Simd<T, N>` are Copy types.
+        unsafe { slice.as_ptr().cast::<Self>().read_unaligned() }
     }
 
     /// Performs lanewise conversion of a SIMD vector's elements to another SIMD-valid type.


### PR DESCRIPTION
Discussed on Zulip. This also bit @the8472 when converting the SIMD string search patch to `std::simd` IIRC.

CC @rust-lang/wg-const-eval in case anybody cares that we're using `#![feature(const_ptr_read)]` here (Rationale: This whole API is unstable anyway, and this can be implemented without it, just it doesn't get vectorized).