### PR TITLE
Change Mask element to match Simd element

### DIFF
--- a/crates/core_simd/src/elements/const_ptr.rs
+++ b/crates/core_simd/src/elements/const_ptr.rs
@@ -79,7 +79,7 @@ where
     type Usize = Simd<usize, LANES>;
     type Isize = Simd<isize, LANES>;
     type MutPtr = Simd<*mut T, LANES>;
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<*const T, LANES>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/elements/int.rs
+++ b/crates/core_simd/src/elements/int.rs
@@ -1,7 +1,5 @@
 use super::sealed::Sealed;
-use crate::simd::{
-    intrinsics, LaneCount, Mask, Simd, SimdElement, SimdPartialOrd, SupportedLaneCount,
-};
+use crate::simd::{intrinsics, LaneCount, Mask, Simd, SimdPartialOrd, SupportedLaneCount};
 
 /// Operations on SIMD vectors of signed integers.
 pub trait SimdInt: Copy + Sealed {
@@ -196,7 +194,7 @@ macro_rules! impl_trait {
         where
             LaneCount<LANES>: SupportedLaneCount,
         {
-            type Mask = Mask<<$ty as SimdElement>::Mask, LANES>;
+            type Mask = Mask<$ty, LANES>;
             type Scalar = $ty;
 
             #[inline]

--- a/crates/core_simd/src/elements/mut_ptr.rs
+++ b/crates/core_simd/src/elements/mut_ptr.rs
@@ -74,7 +74,7 @@ where
     type Usize = Simd<usize, LANES>;
     type Isize = Simd<isize, LANES>;
     type ConstPtr = Simd<*const T, LANES>;
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<*mut T, LANES>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/eq.rs
+++ b/crates/core_simd/src/eq.rs
@@ -1,5 +1,5 @@
 use crate::simd::{
-    intrinsics, LaneCount, Mask, Simd, SimdConstPtr, SimdElement, SimdMutPtr, SupportedLaneCount,
+    intrinsics, LaneCount, Mask, Simd, SimdConstPtr, SimdMutPtr, SupportedLaneCount,
 };
 
 /// Parallel `PartialEq`.
@@ -23,7 +23,7 @@ macro_rules! impl_number {
         where
             LaneCount<LANES>: SupportedLaneCount,
         {
-            type Mask = Mask<<$number as SimdElement>::Mask, LANES>;
+            type Mask = Mask<$number, LANES>;
 
             #[inline]
             fn simd_eq(self, other: Self) -> Self::Mask {
@@ -78,16 +78,16 @@ impl<T, const LANES: usize> SimdPartialEq for Simd<*const T, LANES>
 where
     LaneCount<LANES>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<*const T, LANES>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {
-        self.addr().simd_eq(other.addr())
+        self.addr().simd_eq(other.addr()).cast()
     }
 
     #[inline]
     fn simd_ne(self, other: Self) -> Self::Mask {
-        self.addr().simd_ne(other.addr())
+        self.addr().simd_ne(other.addr()).cast()
     }
 }
 
@@ -95,15 +95,15 @@ impl<T, const LANES: usize> SimdPartialEq for Simd<*mut T, LANES>
 where
     LaneCount<LANES>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<*mut T, LANES>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {
-        self.addr().simd_eq(other.addr())
+        self.addr().simd_eq(other.addr()).cast()
     }
 
     #[inline]
     fn simd_ne(self, other: Self) -> Self::Mask {
-        self.addr().simd_ne(other.addr())
+        self.addr().simd_ne(other.addr()).cast()
     }
 }

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -89,7 +89,7 @@ impl_element! { isize }
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
 #[repr(transparent)]
-pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T::Mask, LANES>)
+pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where
     T: SimdElement,
     LaneCount<LANES>: SupportedLaneCount;
@@ -197,7 +197,7 @@ where
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub fn cast<U: SimdElement>(self) -> Mask<U, LANES> {
-        Mask(self.0.convert())
+        Mask(self.0.cast())
     }
 
     /// Tests the value of the specified lane.

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -531,24 +531,3 @@ where
         *self ^= Self::splat(rhs);
     }
 }
-
-macro_rules! impl_from {
-    { $from:ty  => $($to:ty),* } => {
-        $(
-        impl<const LANES: usize> From<Mask<$from, LANES>> for Mask<$to, LANES>
-        where
-            LaneCount<LANES>: SupportedLaneCount,
-        {
-            #[inline]
-            fn from(value: Mask<$from, LANES>) -> Self {
-                value.cast()
-            }
-        }
-        )*
-    }
-}
-impl_from! { i8 => i16, i32, i64, isize }
-impl_from! { i16 => i32, i64, isize, i8 }
-impl_from! { i32 => i64, isize, i8, i16 }
-impl_from! { i64 => isize, i8, i16, i32 }
-impl_from! { isize => i8, i16, i32, i64 }

--- a/crates/core_simd/src/ord.rs
+++ b/crates/core_simd/src/ord.rs
@@ -220,22 +220,22 @@ where
 {
     #[inline]
     fn simd_lt(self, other: Self) -> Self::Mask {
-        self.addr().simd_lt(other.addr())
+        self.addr().simd_lt(other.addr()).cast()
     }
 
     #[inline]
     fn simd_le(self, other: Self) -> Self::Mask {
-        self.addr().simd_le(other.addr())
+        self.addr().simd_le(other.addr()).cast()
     }
 
     #[inline]
     fn simd_gt(self, other: Self) -> Self::Mask {
-        self.addr().simd_gt(other.addr())
+        self.addr().simd_gt(other.addr()).cast()
     }
 
     #[inline]
     fn simd_ge(self, other: Self) -> Self::Mask {
-        self.addr().simd_ge(other.addr())
+        self.addr().simd_ge(other.addr()).cast()
     }
 }
 
@@ -269,22 +269,22 @@ where
 {
     #[inline]
     fn simd_lt(self, other: Self) -> Self::Mask {
-        self.addr().simd_lt(other.addr())
+        self.addr().simd_lt(other.addr()).cast()
     }
 
     #[inline]
     fn simd_le(self, other: Self) -> Self::Mask {
-        self.addr().simd_le(other.addr())
+        self.addr().simd_le(other.addr()).cast()
     }
 
     #[inline]
     fn simd_gt(self, other: Self) -> Self::Mask {
-        self.addr().simd_gt(other.addr())
+        self.addr().simd_gt(other.addr()).cast()
     }
 
     #[inline]
     fn simd_ge(self, other: Self) -> Self::Mask {
-        self.addr().simd_ge(other.addr())
+        self.addr().simd_ge(other.addr()).cast()
     }
 }
 

--- a/crates/core_simd/src/select.rs
+++ b/crates/core_simd/src/select.rs
@@ -1,9 +1,9 @@
 use crate::simd::intrinsics;
-use crate::simd::{LaneCount, Mask, MaskElement, Simd, SimdElement, SupportedLaneCount};
+use crate::simd::{LaneCount, Mask, Simd, SimdElement, SupportedLaneCount};
 
 impl<T, const LANES: usize> Mask<T, LANES>
 where
-    T: MaskElement,
+    T: SimdElement,
     LaneCount<LANES>: SupportedLaneCount,
 {
     /// Choose lanes from two vectors.
@@ -23,14 +23,11 @@ where
     /// ```
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn select<U>(
+    pub fn select(
         self,
-        true_values: Simd<U, LANES>,
-        false_values: Simd<U, LANES>,
-    ) -> Simd<U, LANES>
-    where
-        U: SimdElement<Mask = T>,
-    {
+        true_values: Simd<T, LANES>,
+        false_values: Simd<T, LANES>,
+    ) -> Simd<T, LANES> {
         // Safety: The mask has been cast to a vector of integers,
         // and the operands to select between are vectors of the same type and length.
         unsafe { intrinsics::simd_select(self.to_int(), true_values, false_values) }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -104,18 +104,13 @@ macro_rules! test_mask_api {
 
             #[test]
             fn cast() {
-                fn cast_impl<T: core_simd::simd::MaskElement>()
-                where
-                    Mask<$type, 8>: Into<Mask<T, 8>>,
+                fn cast_impl<T: core_simd::simd::SimdElement>()
                 {
                     let values = [true, false, false, true, false, false, true, false];
                     let mask = Mask::<$type, 8>::from_array(values);
 
                     let cast_mask = mask.cast::<T>();
                     assert_eq!(values, cast_mask.to_array());
-
-                    let into_mask: Mask<T, 8> = mask.into();
-                    assert_eq!(values, into_mask.to_array());
                 }
 
                 cast_impl::<i8>();
@@ -123,6 +118,15 @@ macro_rules! test_mask_api {
                 cast_impl::<i32>();
                 cast_impl::<i64>();
                 cast_impl::<isize>();
+                cast_impl::<u8>();
+                cast_impl::<u16>();
+                cast_impl::<u32>();
+                cast_impl::<u64>();
+                cast_impl::<usize>();
+                cast_impl::<f32>();
+                cast_impl::<f64>();
+                cast_impl::<*mut u8>();
+                cast_impl::<*const u8>();
             }
 
             #[cfg(feature = "generic_const_exprs")]
@@ -148,14 +152,4 @@ mod mask_api {
     test_mask_api! { i32 }
     test_mask_api! { i64 }
     test_mask_api! { isize }
-}
-
-#[test]
-fn convert() {
-    use core_simd::simd::Mask;
-    let values = [true, false, false, true, false, false, true, false];
-    assert_eq!(
-        Mask::<i8, 8>::from_array(values),
-        Mask::<i32, 8>::from_array(values).into()
-    );
 }


### PR DESCRIPTION
It's a little confusing for the mask element type to be generic over "equivalently sized" integers, rather than the actual element type.  This PR changes e.g. `Mask<isize, N>` to `Mask<*const u8, N>`, or `Mask<usize, N>`, or whatever the element type actually is.  Another PR in the future could probably remove the `MaskElement` trait entirely, but I think this is a good start.

Also, I removed the `From` implementation for converting masks, because with this many valid element types it's not really reasonable to implement.