### PR TITLE
Document alternatives to Mask<T, LANES> that guarantee layout. Fixes #332

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -89,9 +89,10 @@ impl_element! { isize }
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
 ///
-/// For a type with layout guaranteed equivalent to `[T; LANES]`, use
-/// `Simd<T, LANES>`. For a type with layout guaranteed to use 1 bit per
-/// lane (padded up to the next integer type), use [`ToBitMask::BitMask`].
+/// For a type with size guaranteed equivalent to `[T; LANES]`, use
+/// `Simd<T, LANES>`. For a type with size guaranteed to use 1 bit per
+/// lane (padded up to the next integer type or), use [`ToBitMask::BitMask`]
+/// or (with crate feature `generic_const_exprs`) `ToBitMaskArray::BitMaskArray`.
 #[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -88,6 +88,10 @@ impl_element! { isize }
 /// The layout of this type is unspecified, and may change between platforms
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
+///
+/// For a type with layout guaranteed equivalent to `[T; LANES]`, use 
+/// `SIMD<T, LANES>`. For a type with layout guaranteed to use 1 bit per
+/// lane (padded up to full bytes), use `LANES::BitMask`.
 #[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -89,7 +89,7 @@ impl_element! { isize }
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
 ///
-/// For a type with size guaranteed equivalent to `[T; LANES]`, use
+/// For a type with size guaranteed equal to `[T; LANES]`, use
 /// `Simd<T, LANES>`. For a type with size guaranteed to use 1 bit per
 /// lane (padded up to the next integer type or), use [`ToBitMask::BitMask`]
 /// or (with crate feature `generic_const_exprs`) `ToBitMaskArray::BitMaskArray`.

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -90,7 +90,7 @@ impl_element! { isize }
 /// `[T; LANES]`.
 ///
 /// For a type with layout guaranteed equivalent to `[T; LANES]`, use
-/// `SIMD<T, LANES>`. For a type with layout guaranteed to use 1 bit per
+/// `Simd<T, LANES>`. For a type with layout guaranteed to use 1 bit per
 /// lane (padded up to full bytes), use `LANES::BitMask`.
 #[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -89,7 +89,7 @@ impl_element! { isize }
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
 ///
-/// For a type with layout guaranteed equivalent to `[T; LANES]`, use 
+/// For a type with layout guaranteed equivalent to `[T; LANES]`, use
 /// `SIMD<T, LANES>`. For a type with layout guaranteed to use 1 bit per
 /// lane (padded up to full bytes), use `LANES::BitMask`.
 #[repr(transparent)]

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -91,7 +91,7 @@ impl_element! { isize }
 ///
 /// For a type with layout guaranteed equivalent to `[T; LANES]`, use
 /// `Simd<T, LANES>`. For a type with layout guaranteed to use 1 bit per
-/// lane (padded up to full bytes), use `LANES::BitMask`.
+/// lane (padded up to the next integer type), use [`ToBitMask::BitMask`].
 #[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where


### PR DESCRIPTION
Intended to fix #332.