### PR TITLE
Implement common swizzle operations.

### DIFF
--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -369,7 +369,7 @@ where
     ///
     /// This is equivalent to computing `&self[OFFSET..OFFSET+LEN]` on
     /// the underlying array.
-    /// 
+    ///
     /// ```
     /// # #![feature(portable_simd)]
     /// # use core::simd::Simd;
@@ -377,12 +377,14 @@ where
     /// let y = x.slice::<2, 4>();
     /// assert_eq!(y.to_array(), [2, 3, 4, 5]);
     /// ```
-    /// 
+    ///
     /// Will be rejected at compile time if `OFFSET + LEN > LANES`.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn slice<const OFFSET: usize, const LEN: usize>(self) -> Simd<T, LEN> 
-        where LaneCount<LEN>: SupportedLaneCount {
+    pub fn slice<const OFFSET: usize, const LEN: usize>(self) -> Simd<T, LEN>
+    where
+        LaneCount<LEN>: SupportedLaneCount,
+    {
         const fn slice_index<const LEN: usize>(offset: usize, lanes: usize) -> [usize; LEN] {
             assert!(offset + LEN <= lanes, "slice out of bounds");
             let mut index = [0; LEN];
@@ -394,17 +396,19 @@ where
             index
         }
         struct Slice<const OFFSET: usize>;
-        impl<const OFFSET: usize, const LEN: usize, const LANES: usize> Swizzle<LANES, LEN> for Slice<OFFSET> {
+        impl<const OFFSET: usize, const LEN: usize, const LANES: usize> Swizzle<LANES, LEN>
+            for Slice<OFFSET>
+        {
             const INDEX: [usize; LEN] = slice_index::<LEN>(OFFSET, LANES);
         }
         Slice::<OFFSET>::swizzle(self)
     }
 
     /// Concatenates two vectors of equal length.
-    /// 
+    ///
     /// Due to limitations in const generics, the length of the resulting vector cannot be inferred
     /// from the input vectors. You must specify it explicitly.
-    /// 
+    ///
     /// ```
     /// # #![feature(portable_simd)]
     /// # use core::simd::Simd;
@@ -413,10 +417,11 @@ where
     /// let z = x.concat_to::<8>(y);
     /// assert_eq!(z.to_array(), [0, 1, 2, 3, 4, 5, 6, 7]);
     /// ```
-    /// 
+    ///
     /// Will be rejected at compile time if `LANES * 2 != DOUBLE_LANES`.
     pub fn concat_to<const DOUBLE_LANES: usize>(self, other: Self) -> Simd<T, DOUBLE_LANES>
-        where LaneCount<DOUBLE_LANES>: SupportedLaneCount
+    where
+        LaneCount<DOUBLE_LANES>: SupportedLaneCount,
     {
         const fn concat_index<const DOUBLE_LANES: usize>(lanes: usize) -> [Which; DOUBLE_LANES] {
             assert!(lanes * 2 == DOUBLE_LANES);
@@ -437,10 +442,10 @@ where
     }
 
     /// For each lane `i`, swaps it with lane `i ^ SWAP_MASK`.
-    /// 
+    ///
     /// Also known as `grev` in the RISC-V Bitmanip specification, this is a powerful
     /// swizzle operation that can implement many common patterns as special cases.
-    /// 
+    ///
     /// ```
     /// # #![feature(portable_simd)]
     /// # use core::simd::Simd;
@@ -454,9 +459,9 @@ where
     /// // Reverse lanes, within each 4-lane group:
     /// assert_eq!(x.general_reverse::<3>().to_array(), [3, 2, 1, 0, 7, 6, 5, 4]);
     /// ```
-    /// 
+    ///
     /// Commonly useful for horizontal reductions, for example:
-    /// 
+    ///
     /// ```
     /// # #![feature(portable_simd)]
     /// # use core::simd::Simd;

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -484,6 +484,9 @@ where
     /// ```
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    #[doc(alias = "grev")]
+    #[doc(alias = "butterfly")]
+    #[doc(alias = "bfly")]
     pub fn general_reverse<const SWAP_MASK: usize>(self) -> Self {
         const fn general_reverse_index<const LANES: usize>(swap_mask: usize) -> [usize; LANES] {
             let mut index = [0; LANES];

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -454,6 +454,19 @@ where
     /// // Reverse lanes, within each 4-lane group:
     /// assert_eq!(x.general_reverse::<3>().to_array(), [3, 2, 1, 0, 7, 6, 5, 4]);
     /// ```
+    /// 
+    /// Commonly useful for horizontal reductions, for example:
+    /// 
+    /// ```
+    /// # #![feature(portable_simd)]
+    /// # use core::simd::Simd;
+    /// let x = Simd::from_array([0u32, 1, 2, 3, 4, 5, 6, 7]);
+    /// let x = x + x.general_reverse::<1>();
+    /// let x = x + x.general_reverse::<2>();
+    /// let x = x + x.general_reverse::<4>();
+    /// assert_eq!(x.to_array(), [28, 28, 28, 28, 28, 28, 28, 28]);
+    /// ```
+
     pub fn general_reverse<const SWAP_MASK: usize>(self) -> Self {
         const fn general_reverse_index<const LANES: usize>(swap_mask: usize) -> [usize; LANES] {
             let mut index = [0; LANES];

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -419,6 +419,8 @@ where
     /// ```
     ///
     /// Will be rejected at compile time if `LANES * 2 != DOUBLE_LANES`.
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn concat_to<const DOUBLE_LANES: usize>(self, other: Self) -> Simd<T, DOUBLE_LANES>
     where
         LaneCount<DOUBLE_LANES>: SupportedLaneCount,
@@ -471,7 +473,8 @@ where
     /// let x = x + x.general_reverse::<4>();
     /// assert_eq!(x.to_array(), [28, 28, 28, 28, 28, 28, 28, 28]);
     /// ```
-
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn general_reverse<const SWAP_MASK: usize>(self) -> Self {
         const fn general_reverse_index<const LANES: usize>(swap_mask: usize) -> [usize; LANES] {
             let mut index = [0; LANES];

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -461,7 +461,7 @@ where
     /// This is a powerful swizzle operation that can implement many common patterns as special cases.
     /// For power-of-2 swap masks, this produces the [butterfly shuffles](https://en.wikipedia.org/wiki/Butterfly_network)
     /// that are often useful for horizontal reductions.
-    /// 
+    ///
     /// A similar operation (operating on bits instead of lanes) is known as `grev` in the RISC-V
     /// Bitmanip specification.
     ///

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -382,6 +382,9 @@ where
     /// ```
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    // TODO: when `generic_const_exprs` supports it, provide
+    //   `pub fn split(self) -> [Simd<T, {LANES / 2}>; 2]`
+    // and deprecate `split_to`.
     pub fn split_to<const HALF_LANES: usize>(self) -> [Simd<T, HALF_LANES>; 2]
     where
         LaneCount<HALF_LANES>: SupportedLaneCount,
@@ -428,6 +431,9 @@ where
     /// Will be rejected at compile time if `LANES * 2 != DOUBLE_LANES`.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    // TODO: when `generic_const_exprs` supports it, provide
+    //   `pub fn concat(self, other: Self) -> Simd<T, {LANES * 2}>`
+    // and deprecate `concat_to`.
     pub fn concat_to<const DOUBLE_LANES: usize>(self, other: Self) -> Simd<T, DOUBLE_LANES>
     where
         LaneCount<DOUBLE_LANES>: SupportedLaneCount,
@@ -452,8 +458,12 @@ where
 
     /// For each lane `i`, swaps it with lane `i ^ SWAP_MASK`.
     ///
-    /// Also known as `grev` in the RISC-V Bitmanip specification, this is a powerful
-    /// swizzle operation that can implement many common patterns as special cases.
+    /// This is a powerful swizzle operation that can implement many common patterns as special cases.
+    /// For power-of-2 swap masks, this produces the [butterfly shuffles](https://en.wikipedia.org/wiki/Butterfly_network)
+    /// that are often useful for horizontal reductions.
+    /// 
+    /// A similar operation (operating on bits instead of lanes) is known as `grev` in the RISC-V
+    /// Bitmanip specification.
     ///
     /// ```
     /// # #![feature(portable_simd)]

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -372,7 +372,8 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::Simd;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd::Simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd::Simd;
     /// let x = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
     /// let y = x.slice::<2, 4>();
     /// assert_eq!(y.to_array(), [2, 3, 4, 5]);
@@ -381,7 +382,7 @@ where
     /// Will be rejected at compile time if `OFFSET + LEN > LANES`.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn slice<const OFFSET: usize, const LEN: usize>(self) -> Simd<T, LEN>
+    pub fn split_to<const OFFSET: usize, const LEN: usize>(self) -> Simd<T, LEN>
     where
         LaneCount<LEN>: SupportedLaneCount,
     {
@@ -411,7 +412,8 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::Simd;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd::Simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd::Simd;
     /// let x = Simd::from_array([0, 1, 2, 3]);
     /// let y = Simd::from_array([4, 5, 6, 7]);
     /// let z = x.concat_to::<8>(y);
@@ -450,7 +452,8 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::Simd;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd::Simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd::Simd;
     /// let x = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
     /// // Swap adjacent lanes:
     /// assert_eq!(x.general_reverse::<1>().to_array(), [1, 0, 3, 2, 5, 4, 7, 6]);
@@ -466,7 +469,8 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::Simd;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd::Simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd::Simd;
     /// let x = Simd::from_array([0u32, 1, 2, 3, 4, 5, 6, 7]);
     /// let x = x + x.general_reverse::<1>();
     /// let x = x + x.general_reverse::<2>();

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -101,13 +101,25 @@ fn concat() {
 fn general_reverse() {
     let x = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
     // Swap adjacent lanes:
-    assert_eq!(x.general_reverse::<1>().to_array(), [1, 0, 3, 2, 5, 4, 7, 6]);
+    assert_eq!(
+        x.general_reverse::<1>().to_array(),
+        [1, 0, 3, 2, 5, 4, 7, 6]
+    );
     // Swap lanes separated by distance 2:
-    assert_eq!(x.general_reverse::<2>().to_array(), [2, 3, 0, 1, 6, 7, 4, 5]);
+    assert_eq!(
+        x.general_reverse::<2>().to_array(),
+        [2, 3, 0, 1, 6, 7, 4, 5]
+    );
     // Swap lanes separated by distance 4:
-    assert_eq!(x.general_reverse::<4>().to_array(), [4, 5, 6, 7, 0, 1, 2, 3]);
+    assert_eq!(
+        x.general_reverse::<4>().to_array(),
+        [4, 5, 6, 7, 0, 1, 2, 3]
+    );
     // Reverse lanes, within each 4-lane group:
-    assert_eq!(x.general_reverse::<3>().to_array(), [3, 2, 1, 0, 7, 6, 5, 4]);
+    assert_eq!(
+        x.general_reverse::<3>().to_array(),
+        [3, 2, 1, 0, 7, 6, 5, 4]
+    );
 }
 
 #[test]

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -95,6 +95,7 @@ fn concat_equal_width() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[cfg(feature = "all_lane_counts")]
 fn concat_different_width() {
     let x = Simd::from_array([0, 1, 2, 3]);
     let y = Simd::from_array([4, 5]);

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -109,3 +109,13 @@ fn general_reverse() {
     // Reverse lanes, within each 4-lane group:
     assert_eq!(x.general_reverse::<3>().to_array(), [3, 2, 1, 0, 7, 6, 5, 4]);
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn general_reverse_sum() {
+    let x = Simd::from_array([0u32, 1, 2, 3, 4, 5, 6, 7]);
+    let x = x + x.general_reverse::<1>();
+    let x = x + x.general_reverse::<2>();
+    let x = x + x.general_reverse::<4>();
+    assert_eq!(x.to_array(), [28, 28, 28, 28, 28, 28, 28, 28]);
+}

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -109,22 +109,22 @@ fn general_reverse() {
     let x = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
     // Swap adjacent lanes:
     assert_eq!(
-        x.general_reverse::<1>().to_array(),
+        x.swizzle_to_xor_indices::<1>().to_array(),
         [1, 0, 3, 2, 5, 4, 7, 6]
     );
     // Swap lanes separated by distance 2:
     assert_eq!(
-        x.general_reverse::<2>().to_array(),
+        x.swizzle_to_xor_indices::<2>().to_array(),
         [2, 3, 0, 1, 6, 7, 4, 5]
     );
     // Swap lanes separated by distance 4:
     assert_eq!(
-        x.general_reverse::<4>().to_array(),
+        x.swizzle_to_xor_indices::<4>().to_array(),
         [4, 5, 6, 7, 0, 1, 2, 3]
     );
     // Reverse lanes, within each 4-lane group:
     assert_eq!(
-        x.general_reverse::<3>().to_array(),
+        x.swizzle_to_xor_indices::<3>().to_array(),
         [3, 2, 1, 0, 7, 6, 5, 4]
     );
 }
@@ -133,8 +133,8 @@ fn general_reverse() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn general_reverse_sum() {
     let x = Simd::from_array([0u32, 1, 2, 3, 4, 5, 6, 7]);
-    let x = x + x.general_reverse::<1>();
-    let x = x + x.general_reverse::<2>();
-    let x = x + x.general_reverse::<4>();
+    let x = x + x.swizzle_to_xor_indices::<1>();
+    let x = x + x.swizzle_to_xor_indices::<2>();
+    let x = x + x.swizzle_to_xor_indices::<4>();
     assert_eq!(x.to_array(), [28, 28, 28, 28, 28, 28, 28, 28]);
 }

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -74,3 +74,38 @@ fn interleave_one() {
     assert_eq!(even, a);
     assert_eq!(odd, b);
 }
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn slice() {
+    let a = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
+    let lo = a.slice::<0, 4>();
+    let mid = a.slice::<3, 2>();
+    let hi = a.slice::<4, 4>();
+    assert_eq!(lo.to_array(), [0, 1, 2, 3]);
+    assert_eq!(mid.to_array(), [3, 4]);
+    assert_eq!(hi.to_array(), [4, 5, 6, 7]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn concat() {
+    let x = Simd::from_array([0, 1, 2, 3]);
+    let y = Simd::from_array([4, 5, 6, 7]);
+    let z = x.concat_to::<8>(y);
+    assert_eq!(z.to_array(), [0, 1, 2, 3, 4, 5, 6, 7]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn general_reverse() {
+    let x = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
+    // Swap adjacent lanes:
+    assert_eq!(x.general_reverse::<1>().to_array(), [1, 0, 3, 2, 5, 4, 7, 6]);
+    // Swap lanes separated by distance 2:
+    assert_eq!(x.general_reverse::<2>().to_array(), [2, 3, 0, 1, 6, 7, 4, 5]);
+    // Swap lanes separated by distance 4:
+    assert_eq!(x.general_reverse::<4>().to_array(), [4, 5, 6, 7, 0, 1, 2, 3]);
+    // Reverse lanes, within each 4-lane group:
+    assert_eq!(x.general_reverse::<3>().to_array(), [3, 2, 1, 0, 7, 6, 5, 4]);
+}

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -79,11 +79,8 @@ fn interleave_one() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn slice() {
     let a = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
-    let lo = a.slice::<0, 4>();
-    let mid = a.slice::<3, 2>();
-    let hi = a.slice::<4, 4>();
+    let [lo, hi] = a.split_to::<4>();
     assert_eq!(lo.to_array(), [0, 1, 2, 3]);
-    assert_eq!(mid.to_array(), [3, 4]);
     assert_eq!(hi.to_array(), [4, 5, 6, 7]);
 }
 

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -79,18 +79,27 @@ fn interleave_one() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn slice() {
     let a = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
-    let [lo, hi] = a.split_to::<4>();
+    let [lo, hi] = a.split();
     assert_eq!(lo.to_array(), [0, 1, 2, 3]);
     assert_eq!(hi.to_array(), [4, 5, 6, 7]);
 }
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn concat() {
+fn concat_equal_width() {
     let x = Simd::from_array([0, 1, 2, 3]);
     let y = Simd::from_array([4, 5, 6, 7]);
-    let z = x.concat_to::<8>(y);
+    let z = x.concat(y);
     assert_eq!(z.to_array(), [0, 1, 2, 3, 4, 5, 6, 7]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn concat_different_width() {
+    let x = Simd::from_array([0, 1, 2, 3]);
+    let y = Simd::from_array([4, 5]);
+    let z = x.concat(y);
+    assert_eq!(z.to_array(), [0, 1, 2, 3, 4, 5]);
 }
 
 #[test]


### PR DESCRIPTION
`concat` and `slice` address #277.

`general_reverse` is useful for horizontal reductions, bitonic sorting, and many similar cases.