### PR TITLE
Remove formats `[T; N]` does not impl

### DIFF
--- a/crates/core_simd/src/fmt.rs
+++ b/crates/core_simd/src/fmt.rs
@@ -14,6 +14,7 @@ where
     /// let floats = Simd::<f32, 4>::splat(-1.0);
     /// assert_eq!(format!("{:?}", [-1.0; 4]), format!("{:?}", floats));
     /// ```
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <[T] as fmt::Debug>::fmt(self.as_array(), f)
     }

--- a/crates/core_simd/src/fmt.rs
+++ b/crates/core_simd/src/fmt.rs
@@ -6,18 +6,15 @@ where
     LaneCount<LANES>: SupportedLaneCount,
     T: SimdElement + fmt::Debug,
 {
+    /// A `Simd<T, N>` has a debug format like the one for `[T]`:
+    /// ```
+    /// # #![feature(portable_simd)]
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd::Simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd::Simd;
+    /// let floats = Simd::<f32, 4>::splat(-1.0);
+    /// assert_eq!(format!("{:?}", [-1.0; 4]), format!("{:?}", floats));
+    /// ```
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        #[repr(transparent)]
-        struct Wrapper<'a, T: fmt::Debug>(&'a T);
-
-        impl<T: fmt::Debug> fmt::Debug for Wrapper<'_, T> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                self.0.fmt(f)
-            }
-        }
-
-        f.debug_list()
-            .entries(self.as_array().iter().map(|x| Wrapper(x)))
-            .finish()
+        <[T] as fmt::Debug>::fmt(self.as_array(), f)
     }
 }


### PR DESCRIPTION
This is inconsistent with how arrays and slices format, and it also causes unnecessary code bloat in libcore. We can revisit this if people ever agree on doing these formatters for the other slice-y types.
