### PR TITLE
lane -> element for `core::simd::Simd`

### DIFF
--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -709,7 +709,7 @@ where
             Mask::from_int_unchecked(tfvec)
         };
 
-        // Two vectors are equal if they are elementwise equal
+        // Two vectors are equal if all elements are equal when compared elementwise
         mask.all()
     }
 
@@ -722,7 +722,7 @@ where
             Mask::from_int_unchecked(tfvec)
         };
 
-        // Two vectors are non-equal if they are elementwise non-equal
+        // Two vectors are non-equal if any elements are non-equal when compared elementwise
         mask.any()
     }
 }

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -8,7 +8,12 @@ use crate::simd::{
 /// `Simd<T, N>` supports the operators (+, *, etc.) that `T` does in "elementwise" fashion.
 /// These take the element at each index from the left-hand side and right-hand side,
 /// perform the operation, then return the result in the same index in a vector of equal size.
-/// In other words, an elementwise operation is equivalent to a zip, then map.
+/// However, `Simd` differs from normal iteration and normal arrays:
+/// - `Simd<T, N>` executes `N` operations in a single step with no `break`s
+/// - `Simd<T, N>` can have an alignment greater than `T`, for better mechanical sympathy
+///
+/// By always imposing these constraints on `Simd`, it is easier to compile elementwise operations
+/// into machine instructions that can themselves be executed in parallel.
 ///
 /// ```rust
 /// # #![feature(portable_simd)]

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -830,7 +830,7 @@ where
     T: SimdElement,
 {
     fn from(array: [T; N]) -> Self {
-        Self(array)
+        Self::from_array(array)
     }
 }
 


### PR DESCRIPTION
A while ago we began saying T, N instead of T, LANES in reference to Simd. At some point that leaked in to us checking in code with const N: usize. After a while, we had a discussion and agreed that "lanes", while common, is unnecessary jargon for Rust learners who aren't familiar with SIMD, and is fully interchangeable with terms for arrays like element and index.

But we never acted on that. Let's update the main type's docs, at least. VL has been proposed here because Simd appears beside [T; N] often, so getting ahead on assigning a name to Simd's specific N may help? The example tweaks enable removing a slated-for-removal nightly fn.

I have the rest of this as it would go across the rest of the module's API docs waiting in the wings, but I figured that any kibitzing over how this should be done should be handled on Simd's docs because it's pretty procedurally applied elsewhere. There's basically "how we talk about Simd" and "how we talk about Mask" as the two major points of interest, so once both of those are done, and they can be mostly-separate discussions, it's robotic.