### PR TITLE
Use the new `load`/`store` functions in `{from,to}_slice`

### DIFF
--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -263,11 +263,9 @@ where
             slice.len() >= Self::N,
             "slice length must be at least the number of elements"
         );
-        assert!(core::mem::size_of::<Self>() == Self::N * core::mem::size_of::<T>());
-        // Safety:
-        // - We've checked the length is sufficient.
-        // - `T` and `Simd<T, N>` are Copy types.
-        unsafe { slice.as_ptr().cast::<Self>().read_unaligned() }
+        // SAFETY: We just checked that the slice contains
+        // at least `N` elements.
+        unsafe { Self::load(slice.as_ptr().cast()) }
     }
 
     /// Writes a SIMD vector to the first `N` elements of a slice.
@@ -293,11 +291,9 @@ where
             slice.len() >= Self::N,
             "slice length must be at least the number of elements"
         );
-        assert!(core::mem::size_of::<Self>() == Self::N * core::mem::size_of::<T>());
-        // Safety:
-        // - We've checked the length is sufficient
-        // - `T` and `Simd<T, N>` are Copy types.
-        unsafe { slice.as_mut_ptr().cast::<Self>().write_unaligned(self) }
+        // SAFETY: We just checked that the slice contains
+        // at least `N` elements.
+        unsafe { self.store(slice.as_mut_ptr().cast()) }
     }
 
     /// Performs elementwise conversion of a SIMD vector's elements to another SIMD-valid type.


### PR DESCRIPTION
Cleans the code up a bit and also allows us to use the functions for vectors with padding because the old assertion is now unnecessary.