### PR TITLE
Fix build error on big endian arm/aarch64

### DIFF
--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -16,9 +16,9 @@ where
     #[inline]
     pub fn swizzle_dyn(self, idxs: Simd<u8, N>) -> Self {
         #![allow(unused_imports, unused_unsafe)]
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         use core::arch::aarch64::{uint8x8_t, vqtbl1q_u8, vtbl1_u8};
-        #[cfg(all(target_arch = "arm", target_feature = "v7"))]
+        #[cfg(all(target_arch = "arm", target_feature = "v7", target_endian = "little"))]
         use core::arch::arm::{uint8x8_t, vtbl1_u8};
         #[cfg(target_arch = "wasm32")]
         use core::arch::wasm32 as wasm;
@@ -29,13 +29,24 @@ where
         // SAFETY: Intrinsics covered by cfg
         unsafe {
             match N {
-                #[cfg(target_feature = "neon")]
+                #[cfg(all(
+                    any(
+                        target_arch = "aarch64",
+                        all(target_arch = "arm", target_feature = "v7")
+                    ),
+                    target_feature = "neon",
+                    target_endian = "little"
+                ))]
                 8 => transize(vtbl1_u8, self, idxs),
                 #[cfg(target_feature = "ssse3")]
                 16 => transize(x86::_mm_shuffle_epi8, self, idxs),
                 #[cfg(target_feature = "simd128")]
                 16 => transize(wasm::i8x16_swizzle, self, idxs),
-                #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+                #[cfg(all(
+                    target_arch = "aarch64",
+                    target_feature = "neon",
+                    target_endian = "little"
+                ))]
                 16 => transize(vqtbl1q_u8, self, idxs),
                 #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
                 32 => transize_raw(avx2_pshufb, self, idxs),


### PR DESCRIPTION
stdarch provides arm/aarch64 table lookup intrinsics instructions only on little endian targets (https://github.com/rust-lang/stdarch/commit/51904cd6e53eaeae2450a96fc83f0e5b7f813504), so core_simd currently fails to build on big endian arm/aarch64 targets.

```console
$ cargo build --target armeb-unknown-linux-gnueabi -Z build-std
   Compiling core_simd v0.1.0 (/Users/taiki/projects/forks/rust-lang/portable-simd/crates/core_simd)
error[E0432]: unresolved import `core::arch::arm::vtbl1_u8`
  --> crates/core_simd/src/swizzle_dyn.rs:22:42
   |
22 |         use core::arch::arm::{uint8x8_t, vtbl1_u8};
   |                                          ^^^^^^^^ no `vtbl1_u8` in `core_arch::arch::arm`

$ cargo build --target aarch64_be-unknown-linux-gnu -Z build-std
   Compiling core_simd v0.1.0 (/Users/taiki/projects/forks/rust-lang/portable-simd/crates/core_simd)
error[E0432]: unresolved imports `core::arch::aarch64::vqtbl1q_u8`, `core::arch::aarch64::vtbl1_u8`
  --> crates/core_simd/src/swizzle_dyn.rs:20:46
   |
20 |         use core::arch::aarch64::{uint8x8_t, vqtbl1q_u8, vtbl1_u8};
   |                                              ^^^^^^^^^^  ^^^^^^^^ no `vtbl1_u8` in `core_arch::arch::aarch64`
   |                                              |
   |                                              no `vqtbl1q_u8` in `core_arch::arch::aarch64`
   |
help: a similar name exists in the module
   |
20 |         use core::arch::aarch64::{uint8x8_t, vst1q_u8, vtbl1_u8};
   |                                              ~~~~~~~~
help: a similar name exists in the module
   |
20 |         use core::arch::aarch64::{uint8x8_t, vqtbl1q_u8, vtrn1_u8};
   |                                                          ~~~~~~~~
```

Since https://github.com/rust-lang/rust/pull/111475 (nightly-2023-05-13), builds of these targets are broken due to this bug.