### PR TITLE
Fix subnormals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,20 +175,24 @@ jobs:
       matrix:
         target:
           - armv7-unknown-linux-gnueabihf
-          - thumbv7neon-unknown-linux-gnueabihf
-          - aarch64-unknown-linux-gnu
+          - thumbv7neon-unknown-linux-gnueabihf # includes neon by default
+          - aarch64-unknown-linux-gnu           # includes neon by default
           - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - powerpc64le-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu       # includes altivec by default
           - riscv64gc-unknown-linux-gnu
           # MIPS uses a nonstandard binary representation for NaNs which makes it worth testing
+          # non-nightly since https://github.com/rust-lang/rust/pull/113274
           # - mips-unknown-linux-gnu
           # - mips64-unknown-linux-gnuabi64
+          # Lots of errors in QEMU and no real hardware to test on. Not clear if it's QEMU or bad codegen.
+          # - powerpc64-unknown-linux-gnu
         target_feature: [default]
         include:
-          - { target: powerpc-unknown-linux-gnu, target_feature: "+altivec" }
           - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
+          # Fails due to QEMU floating point errors, probably handling subnormals incorrectly.
+          # This target is somewhat redundant, since ppc64le has altivec as well.
+          # - { target: powerpc-unknown-linux-gnu, target_feature: "+altivec" }
           # We should test this, but cross currently can't run it
           # - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,7 @@ jobs:
           # - mips64-unknown-linux-gnuabi64
         target_feature: [default]
         include:
+          - { target: powerpc-unknown-linux-gnu, target_feature: "+altivec" }
           - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
           # We should test this, but cross currently can't run it
@@ -217,9 +218,6 @@ jobs:
           case "${{ matrix.target_feature }}" in
             default)
               echo "RUSTFLAGS=" >> $GITHUB_ENV;;
-            native)
-              echo "RUSTFLAGS=-Ctarget-cpu=native" >> $GITHUB_ENV
-              ;;
             *)
               echo "RUSTFLAGS=-Ctarget-feature=${{ matrix.target_feature }}" >> $GITHUB_ENV
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,8 @@ jobs:
         include:
           - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
-          - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
+          # We should test this, but cross currently can't run it
+          # - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
         target_feature: [default]
         include:
           - { target: powerpc-unknown-linux-gnu, target_feature: "+altivec" }
-          - { target: powerpc64-unknown-linux-gnu, target_feature: "+power10-vector" }
-          - { target: powerpc64le-unknown-linux-gnu, target_feature: "+power10-vector" }
+          - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
+          - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
           # We should test this, but cross currently can't run it
           # - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
 
@@ -215,8 +215,7 @@ jobs:
       - name: Configure Emulated CPUs
         run: |
           echo "CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc -cpu e600" >> $GITHUB_ENV
-          echo "CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64 -cpu power10" >> $GITHUB_ENV
-          echo "CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER=qemu-riscv64 -cpu rv64,zba=true,zbb=true,v=true,vlen=256,vext_spec=v1.0" >> $GITHUB_ENV
+          # echo "CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER=qemu-riscv64 -cpu rv64,zba=true,zbb=true,v=true,vlen=256,vext_spec=v1.0" >> $GITHUB_ENV
 
       - name: Configure RUSTFLAGS
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         include:
           - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
-          - { target: riscv64gc-unknown-linux-gnu, target_feature: "+zvl128b" }
+          - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,8 @@ jobs:
         target_feature: [default]
         include:
           - { target: powerpc-unknown-linux-gnu, target_feature: "+altivec" }
-          - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
-          - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
+          - { target: powerpc64-unknown-linux-gnu, target_feature: "+power10-vector" }
+          - { target: powerpc64le-unknown-linux-gnu, target_feature: "+power10-vector" }
           # We should test this, but cross currently can't run it
           # - { target: riscv64gc-unknown-linux-gnu, target_feature: "+v,+zvl128b" }
 
@@ -211,6 +211,12 @@ jobs:
           mkdir -p "$HOME/.bin"
           curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
           echo "$HOME/.bin" >> $GITHUB_PATH
+
+      - name: Configure Emulated CPUs
+        run: |
+          echo "CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc -cpu e600" >> $GITHUB_ENV
+          echo "CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_RUNNER=qemu-ppc64 -cpu power10" >> $GITHUB_ENV
+          echo "CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_RUNNER=qemu-riscv64 -cpu rv64,zba=true,zbb=true,v=true,vlen=256,vext_spec=v1.0" >> $GITHUB_ENV
 
       - name: Configure RUSTFLAGS
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,9 @@ jobs:
           # - mips64-unknown-linux-gnuabi64
         target_feature: [default]
         include:
-          - { target: powerpc64-unknown-linux-gnu, target_feature: "native" }
-          - { target: powerpc64le-unknown-linux-gnu, target_feature: "native" }
-          - { target: riscv64gc-unknown-linux-gnu, target_feature: "native" }
+          - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
+          - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
+          - { target: riscv64gc-unknown-linux-gnu, target_feature: "+zvl128b" }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,36 +171,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # TODO: Sadly, we cant configure target-feature in a meaningful way
-      # because `cross` doesn't tell qemu to enable any non-default cpu
-      # features, nor does it give us a way to do so.
-      #
-      # Ultimately, we'd like to do something like [rust-lang/stdarch][stdarch].
-      # This is a lot more complex... but in practice it's likely that we can just
-      # snarf the docker config from around [here][1000-dockerfiles].
-      #
-      # [stdarch]: https://github.com/rust-lang/stdarch/blob/a5db4eaf/.github/workflows/main.yml#L67
-      # [1000-dockerfiles]: https://github.com/rust-lang/stdarch/tree/a5db4eaf/ci/docker
 
       matrix:
         target:
-          - i586-unknown-linux-gnu
-          # 32-bit arm has a few idiosyncracies like having subnormal flushing
-          # to zero on by default. Ideally we'd set
           - armv7-unknown-linux-gnueabihf
           - aarch64-unknown-linux-gnu
-          # Note: The issue above means neither of these mips targets will use
-          # MSA (mips simd) but MIPS uses a nonstandard binary representation
-          # for NaNs which makes it worth testing on despite that.
+          - powerpc-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          # MIPS uses a nonstandard binary representation for NaNs which makes it worth testing
           # - mips-unknown-linux-gnu
           # - mips64-unknown-linux-gnuabi64
-          - riscv64gc-unknown-linux-gnu
-          # TODO this test works, but it appears to time out
-          # - powerpc-unknown-linux-gnu
-          # TODO this test is broken, but it appears to be a problem with QEMU, not us.
-          # - powerpc64le-unknown-linux-gnu
-          # TODO enable this once a new version of cross is released
-          # - powerpc64-unknown-linux-gnu
+        target_feature: ["", "+native"]
 
     steps:
       - uses: actions/checkout@v2
@@ -217,10 +200,13 @@ jobs:
         # being part of the tarball means we can't just use the download/latest
         # URL :(
         run: |
-          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
+          CROSS_URL=https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz
           mkdir -p "$HOME/.bin"
           curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
           echo "$HOME/.bin" >> $GITHUB_PATH
+
+      - name: Configure RUSTFLAGS
+        run: echo "-Ctarget-feature=${{ matrix.target_feature }}" >> $GITHUB_ENV
 
       - name: Test (debug)
         run: cross test --verbose --target=${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
             RUSTFLAGS: ${{ matrix.rustflags }}
 
   cross-tests:
-    name: "${{ matrix.target }} (via cross)"
+    name: "${{ matrix.target_feature }} on ${{ matrix.target }} (via cross)"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -175,6 +175,7 @@ jobs:
       matrix:
         target:
           - armv7-unknown-linux-gnueabihf
+          - thumbv7neon-unknown-linux-gnueabihf
           - aarch64-unknown-linux-gnu
           - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
@@ -183,7 +184,11 @@ jobs:
           # MIPS uses a nonstandard binary representation for NaNs which makes it worth testing
           # - mips-unknown-linux-gnu
           # - mips64-unknown-linux-gnuabi64
-        target_feature: ["", "+native"]
+        target_feature: "default"
+        include:
+          - { target: powerpc64-unknown-linux-gnu, target_feature: "native" }
+          - { target: powerpc64le-unknown-linux-gnu, target_feature: "native" }
+          - { target: riscv64gc-unknown-linux-gnu, target_feature: "native" }
 
     steps:
       - uses: actions/checkout@v2
@@ -206,7 +211,18 @@ jobs:
           echo "$HOME/.bin" >> $GITHUB_PATH
 
       - name: Configure RUSTFLAGS
-        run: echo "-Ctarget-feature=${{ matrix.target_feature }}" >> $GITHUB_ENV
+        shell: bash
+        run: |
+          case "${{ matrix.target_feature }}" in
+            default)
+              echo "RUSTFLAGS=" >> $GITHUB_ENV;;
+            native)
+              echo "RUSTFLAGS=-Ctarget-cpu=native" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "RUSTFLAGS=-Ctarget-feature=${{ matrix.target_feature }}" >> $GITHUB_ENV
+              ;;
+          esac
 
       - name: Test (debug)
         run: cross test --verbose --target=${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
           # MIPS uses a nonstandard binary representation for NaNs which makes it worth testing
           # - mips-unknown-linux-gnu
           # - mips64-unknown-linux-gnuabi64
-        target_feature: "default"
+        target_feature: [default]
         include:
           - { target: powerpc64-unknown-linux-gnu, target_feature: "native" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "native" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,6 @@ jobs:
           # - powerpc64-unknown-linux-gnu
         target_feature: [default]
         include:
-          - { target: powerpc64-unknown-linux-gnu, target_feature: "+vsx" }
           - { target: powerpc64le-unknown-linux-gnu, target_feature: "+vsx" }
           # Fails due to QEMU floating point errors, probably handling subnormals incorrectly.
           # This target is somewhat redundant, since ppc64le has altivec as well.

--- a/crates/core_simd/src/elements/float.rs
+++ b/crates/core_simd/src/elements/float.rs
@@ -336,7 +336,10 @@ macro_rules! impl_trait {
 
             #[inline]
             fn is_subnormal(self) -> Self::Mask {
-                self.abs().simd_ne(Self::splat(0.0)) & (self.to_bits() & Self::splat(Self::Scalar::INFINITY).to_bits()).simd_eq(Simd::splat(0))
+                // On some architectures (e.g. armv7 and some ppc) subnormals are flushed to zero,
+                // so this comparison must be done with integers.
+                let not_zero = self.abs().to_bits().simd_ne(Self::splat(0.0).to_bits());
+                not_zero & (self.to_bits() & Self::splat(Self::Scalar::INFINITY).to_bits()).simd_eq(Simd::splat(0))
             }
 
             #[inline]

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -96,9 +96,11 @@ macro_rules! impl_common_integer_tests {
         test_helpers::test_lanes! {
             fn reduce_sum<const LANES: usize>() {
                 test_helpers::test_1(&|x| {
+                    use test_helpers::subnormals::{flush, flush_in};
                     test_helpers::prop_assert_biteq! (
                         $vector::<LANES>::from_array(x).reduce_sum(),
                         x.iter().copied().fold(0 as $scalar, $scalar::wrapping_add),
+                        flush(x.iter().copied().map(flush_in).fold(0 as $scalar, $scalar::wrapping_add)),
                     );
                     Ok(())
                 });
@@ -106,9 +108,11 @@ macro_rules! impl_common_integer_tests {
 
             fn reduce_product<const LANES: usize>() {
                 test_helpers::test_1(&|x| {
+                    use test_helpers::subnormals::{flush, flush_in};
                     test_helpers::prop_assert_biteq! (
                         $vector::<LANES>::from_array(x).reduce_product(),
                         x.iter().copied().fold(1 as $scalar, $scalar::wrapping_mul),
+                        flush(x.iter().copied().map(flush_in).fold(1 as $scalar, $scalar::wrapping_mul)),
                     );
                     Ok(())
                 });

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -539,6 +539,7 @@ macro_rules! impl_float_tests {
                         }
                         let mut result_scalar_flush = [Scalar::default(); LANES];
                         for i in 0..LANES {
+                            // Comparisons flush-to-zero, but return value selection is _not_ flushed.
                             let mut value = value[i];
                             if flush_in(value) < flush_in(min[i]) {
                                 value = min[i];

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -539,11 +539,11 @@ macro_rules! impl_float_tests {
                         }
                         let mut result_scalar_flush = [Scalar::default(); LANES];
                         for i in 0..LANES {
-                            let mut value = flush_in(value[i]);
-                            if value < flush_in(min[i]) {
+                            let mut value = value[i];
+                            if flush_in(value) < flush_in(min[i]) {
                                 value = min[i];
                             }
-                            if value > flush_in(max[i]) {
+                            if flush_in(value) > flush_in(max[i]) {
                                 value = max[i];
                             }
                             result_scalar_flush[i] = value

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -514,9 +514,11 @@ macro_rules! impl_float_tests {
                     assert!(n_zero.simd_max(p_zero).to_array().iter().all(|x| *x == 0.));
                 }
 
-                #[cfg(not(all(target_arch = "powerpc64", target_feature = "vsx")))]
-                // https://gitlab.com/qemu-project/qemu/-/issues/1780
                 fn simd_clamp<const LANES: usize>() {
+                    if cfg!(all(target_arch = "powerpc64", target_feature = "vsx")) {
+                        // https://gitlab.com/qemu-project/qemu/-/issues/1780
+                        return;
+                    }
                     test_helpers::test_3(&|value: [Scalar; LANES], mut min: [Scalar; LANES], mut max: [Scalar; LANES]| {
                         use test_helpers::subnormals::flush_in;
                         for (min, max) in min.iter_mut().zip(max.iter_mut()) {

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -514,6 +514,8 @@ macro_rules! impl_float_tests {
                     assert!(n_zero.simd_max(p_zero).to_array().iter().all(|x| *x == 0.));
                 }
 
+                #[cfg(not(all(target_arch = "powerpc64", target_feature = "vsx")))]
+                // https://gitlab.com/qemu-project/qemu/-/issues/1780
                 fn simd_clamp<const LANES: usize>() {
                     test_helpers::test_3(&|value: [Scalar; LANES], mut min: [Scalar; LANES], mut max: [Scalar; LANES]| {
                         use test_helpers::subnormals::flush_in;

--- a/crates/core_simd/tests/round.rs
+++ b/crates/core_simd/tests/round.rs
@@ -43,7 +43,7 @@ macro_rules! float_rounding_test {
                 }
 
                 fn fract<const LANES: usize>() {
-                    test_helpers::test_unary_elementwise(
+                    test_helpers::test_unary_elementwise_flush_subnormals(
                         &Vector::<LANES>::fract,
                         &Scalar::fract,
                         &|_| true,

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-[dependencies.proptest]
-version = "0.10"
-default-features = false
-features = ["alloc"]
+[dependencies]
+float_eq = "1.0"
+proptest = { version = "0.10", default-features = false, features = ["alloc"] }
 
 [features]
 all_lane_counts = []

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-float_eq = "1.0"
 proptest = { version = "0.10", default-features = false, features = ["alloc"] }
 
 [features]

--- a/crates/test_helpers/src/biteq.rs
+++ b/crates/test_helpers/src/biteq.rs
@@ -40,8 +40,6 @@ macro_rules! impl_float_biteq {
             fn biteq(&self, other: &Self) -> bool {
                 if self.is_nan() && other.is_nan() {
                     true // exact nan bits don't matter
-                } else if crate::flush_subnormals::<Self>() {
-                    self.to_bits() == other.to_bits() || float_eq::float_eq!(self, other, abs <= 2. * <$type>::EPSILON)
                 } else {
                     self.to_bits() == other.to_bits()
                 }
@@ -115,6 +113,27 @@ impl<T: BitEq> core::fmt::Debug for BitEqWrapper<'_, T> {
     }
 }
 
+#[doc(hidden)]
+pub struct BitEqEitherWrapper<'a, T>(pub &'a T, pub &'a T);
+
+impl<T: BitEq> PartialEq<BitEqEitherWrapper<'_, T>> for BitEqWrapper<'_, T> {
+    fn eq(&self, other: &BitEqEitherWrapper<'_, T>) -> bool {
+        self.0.biteq(other.0) || self.0.biteq(other.1)
+    }
+}
+
+impl<T: BitEq> core::fmt::Debug for BitEqEitherWrapper<'_, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if self.0.biteq(self.1) {
+            self.0.fmt(f)
+        } else {
+            self.0.fmt(f)?;
+            write!(f, " or ")?;
+            self.1.fmt(f)
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! prop_assert_biteq {
     { $a:expr, $b:expr $(,)? } => {
@@ -124,5 +143,14 @@ macro_rules! prop_assert_biteq {
             let b = $b;
             proptest::prop_assert_eq!(BitEqWrapper(&a), BitEqWrapper(&b));
         }
-    }
+    };
+    { $a:expr, $b:expr, $c:expr $(,)? } => {
+        {
+            use $crate::biteq::{BitEqWrapper, BitEqEitherWrapper};
+            let a = $a;
+            let b = $b;
+            let c = $c;
+            proptest::prop_assert_eq!(BitEqWrapper(&a), BitEqEitherWrapper(&b, &c));
+        }
+    };
 }

--- a/crates/test_helpers/src/biteq.rs
+++ b/crates/test_helpers/src/biteq.rs
@@ -40,6 +40,8 @@ macro_rules! impl_float_biteq {
             fn biteq(&self, other: &Self) -> bool {
                 if self.is_nan() && other.is_nan() {
                     true // exact nan bits don't matter
+                } else if crate::flush_subnormals::<Self>() {
+                    self.to_bits() == other.to_bits() || float_eq::float_eq!(self, other, abs <= 2. * <$type>::EPSILON)
                 } else {
                     self.to_bits() == other.to_bits()
                 }

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -6,6 +6,19 @@ pub mod wasm;
 #[macro_use]
 pub mod biteq;
 
+/// Indicates if subnormal floats are flushed to zero.
+pub fn flush_subnormals<T>() -> bool {
+    let is_f32 = core::mem::size_of::<T>() == 4;
+    let ppc_flush = is_f32
+        && cfg!(all(
+            target_arch = "powerpc64",
+            target_endian = "big",
+            not(target_feature = "vsx")
+        ));
+    let arm_flush = is_f32 && cfg!(all(target_arch = "arm", target_feature = "neon"));
+    ppc_flush || arm_flush
+}
+
 /// Specifies the default strategy for testing a type.
 ///
 /// This strategy should be what "makes sense" to test.

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(stdsimd, powerpc_target_feature)]
+
 pub mod array;
 
 #[cfg(target_arch = "wasm32")]
@@ -198,7 +200,7 @@ pub fn test_unary_elementwise_flush_subnormals<
     Vector: Into<[Scalar; LANES]> + From<[Scalar; LANES]> + Copy,
     VectorResult: Into<[ScalarResult; LANES]> + From<[ScalarResult; LANES]> + Copy,
 {
-    let flush = |x: Scalar| FlushSubnormals::flush(fs(FlushSubnormals::flush(x)));
+    let flush = |x: Scalar| subnormals::flush(fs(subnormals::flush_in(x)));
     test_1(&|x: [Scalar; LANES]| {
         proptest::prop_assume!(check(x));
         let result_v: [ScalarResult; LANES] = fv(x.into()).into();
@@ -308,7 +310,7 @@ pub fn test_binary_elementwise_flush_subnormals<
     VectorResult: Into<[ScalarResult; LANES]> + From<[ScalarResult; LANES]> + Copy,
 {
     let flush = |x: Scalar1, y: Scalar2| {
-        FlushSubnormals::flush(fs(FlushSubnormals::flush(x), FlushSubnormals::flush(y)))
+        subnormals::flush(fs(subnormals::flush_in(x), subnormals::flush_in(y)))
     };
     test_2(&|x: [Scalar1; LANES], y: [Scalar2; LANES]| {
         proptest::prop_assume!(check(x, y));

--- a/crates/test_helpers/src/subnormals.rs
+++ b/crates/test_helpers/src/subnormals.rs
@@ -44,13 +44,20 @@ impl_else! { i8, i16, i32, i64, isize, u8, u16, u32, u64, usize }
 
 /// AltiVec should flush subnormal inputs to zero, but QEMU seems to only flush outputs.
 /// https://gitlab.com/qemu-project/qemu/-/issues/1779
-#[cfg(all(target_arch = "powerpc", target_feature = "altivec"))]
+#[cfg(all(
+    any(target_arch = "powerpc", target_arch = "powerpc64"),
+    target_feature = "altivec"
+))]
 fn in_buggy_qemu() -> bool {
     use std::sync::OnceLock;
     static BUGGY: OnceLock<bool> = OnceLock::new();
 
     fn add(x: f32, y: f32) -> f32 {
+        #[cfg(target_arch = "powerpc")]
         use core::arch::powerpc::*;
+        #[cfg(target_arch = "powerpc64")]
+        use core::arch::powerpc64::*;
+
         let array: [f32; 4] =
             unsafe { core::mem::transmute(vec_add(vec_splats(x), vec_splats(y))) };
         array[0]
@@ -59,7 +66,10 @@ fn in_buggy_qemu() -> bool {
     *BUGGY.get_or_init(|| add(-1.0857398e-38, 0.).is_sign_negative())
 }
 
-#[cfg(all(target_arch = "powerpc", target_feature = "altivec"))]
+#[cfg(all(
+    any(target_arch = "powerpc", target_arch = "powerpc64"),
+    target_feature = "altivec"
+))]
 pub fn flush_in<T: FlushSubnormals>(x: T) -> T {
     if in_buggy_qemu() {
         x
@@ -68,7 +78,10 @@ pub fn flush_in<T: FlushSubnormals>(x: T) -> T {
     }
 }
 
-#[cfg(not(all(target_arch = "powerpc", target_feature = "altivec")))]
+#[cfg(not(all(
+    any(target_arch = "powerpc", target_arch = "powerpc64"),
+    target_feature = "altivec"
+)))]
 pub fn flush_in<T: FlushSubnormals>(x: T) -> T {
     x.flush()
 }

--- a/crates/test_helpers/src/subnormals.rs
+++ b/crates/test_helpers/src/subnormals.rs
@@ -13,7 +13,11 @@ macro_rules! impl_float {
         impl FlushSubnormals for $ty {
             fn flush(self) -> Self {
                 let is_f32 = core::mem::size_of::<Self>() == 4;
-                let ppc_flush = is_f32 && cfg!(all(target_arch = "powerpc64", target_endian = "big", not(target_feature = "vsx")));
+                let ppc_flush = is_f32 && cfg!(all(
+                    any(target_arch = "powerpc", all(target_arch = "powerpc64", target_endian = "big")),
+                    target_feature = "altivec",
+                    not(target_feature = "vsx"),
+                ));
                 let arm_flush = is_f32 && cfg!(all(target_arch = "arm", target_feature = "neon"));
                 let flush = ppc_flush || arm_flush;
                 if flush && self.is_subnormal() {

--- a/crates/test_helpers/src/subnormals.rs
+++ b/crates/test_helpers/src/subnormals.rs
@@ -1,0 +1,39 @@
+pub trait FlushSubnormals: Sized {
+    fn flush(self) -> Self {
+        self
+    }
+}
+
+impl<T> FlushSubnormals for *const T {}
+impl<T> FlushSubnormals for *mut T {}
+
+macro_rules! impl_float {
+    { $($ty:ty),* } => {
+        $(
+        impl FlushSubnormals for $ty {
+            fn flush(self) -> Self {
+                let is_f32 = core::mem::size_of::<Self>() == 4;
+                let ppc_flush = is_f32 && cfg!(all(target_arch = "powerpc64", target_endian = "big", not(target_feature = "vsx")));
+                let arm_flush = is_f32 && cfg!(all(target_arch = "arm", target_feature = "neon"));
+                let flush = ppc_flush || arm_flush;
+                if flush && self.is_subnormal() {
+                    <$ty>::copysign(0., self)
+                } else {
+                    self
+                }
+            }
+        }
+        )*
+    }
+}
+
+macro_rules! impl_else {
+    { $($ty:ty),* } => {
+        $(
+        impl FlushSubnormals for $ty {}
+        )*
+    }
+}
+
+impl_float! { f32, f64 }
+impl_else! { i8, i16, i32, i64, isize, u8, u16, u32, u64, usize }


### PR DESCRIPTION
Fixes `is_subnormal` on architectures that flush subnormals to zero, and tests those architectures properly.  Closes #41, #179.