### PR TITLE
Add wrapping negation for unsigned integers

### DIFF
--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -327,6 +327,16 @@ macro_rules! impl_unsigned_tests {
                 }
             }
 
+            test_helpers::test_lanes! {
+                fn wrapping_neg<const LANES: usize>() {
+                    test_helpers::test_unary_elementwise(
+                        &Vector::<LANES>::wrapping_neg,
+                        &Scalar::wrapping_neg,
+                        &|_| true,
+                    );
+                }
+            }
+
             impl_binary_op_test!(Scalar, Add::add, AddAssign::add_assign, Scalar::wrapping_add);
             impl_binary_op_test!(Scalar, Sub::sub, SubAssign::sub_assign, Scalar::wrapping_sub);
             impl_binary_op_test!(Scalar, Mul::mul, MulAssign::mul_assign, Scalar::wrapping_mul);


### PR DESCRIPTION
A compromise that closes #330.

One could argue that since `Simd` is always wrapping, it should implement `Neg`, however this is potentially confusing when this operation effectively always wraps.  It could also be argued that regular unsigned integers wrap in release mode--`Simd` is simply always in release mode :)

A compromise is to add an explicit `wrapping_neg` functions.