### PR TITLE
Add various integer ops

### DIFF
--- a/crates/core_simd/src/elements/int.rs
+++ b/crates/core_simd/src/elements/int.rs
@@ -213,7 +213,7 @@ pub trait SimdInt: Copy + Sealed {
 }
 
 macro_rules! impl_trait {
-    { $($ty:ident ($unsigned:ident)),* } => {
+    { $($ty:ty),* } => {
         $(
         impl<const LANES: usize> Sealed for Simd<$ty, LANES>
         where
@@ -353,18 +353,16 @@ macro_rules! impl_trait {
 
             #[inline]
             fn leading_ones(self) -> Self {
-                use crate::simd::SimdUint;
-                self.cast::<$unsigned>().leading_ones().cast()
+                (!self).leading_zeros()
             }
 
             #[inline]
             fn trailing_ones(self) -> Self {
-                use crate::simd::SimdUint;
-                self.cast::<$unsigned>().trailing_ones().cast()
+                (!self).trailing_zeros()
             }
         }
         )*
     }
 }
 
-impl_trait! { i8 (u8), i16 (u16), i32 (u32), i64 (u64), isize (usize) }
+impl_trait! { i8, i16, i32, i64, isize }

--- a/crates/core_simd/src/elements/int.rs
+++ b/crates/core_simd/src/elements/int.rs
@@ -191,10 +191,29 @@ pub trait SimdInt: Copy + Sealed {
 
     /// Returns the cumulative bitwise "xor" across the lanes of the vector.
     fn reduce_xor(self) -> Self::Scalar;
+
+    /// Reverses the byte order of each element.
+    fn swap_bytes(self) -> Self;
+
+    /// Reverses the order of bits in each elemnent.
+    /// The least significant bit becomes the most significant bit, second least-significant bit becomes second most-significant bit, etc.
+    fn reverse_bits(self) -> Self;
+
+    /// Returns the number of leading zeros in the binary representation of each element.
+    fn leading_zeros(self) -> Self;
+
+    /// Returns the number of trailing zeros in the binary representation of each element.
+    fn trailing_zeros(self) -> Self;
+
+    /// Returns the number of leading ones in the binary representation of each element.
+    fn leading_ones(self) -> Self;
+
+    /// Returns the number of trailing ones in the binary representation of each element.
+    fn trailing_ones(self) -> Self;
 }
 
 macro_rules! impl_trait {
-    { $($ty:ty),* } => {
+    { $($ty:ident ($unsigned:ident)),* } => {
         $(
         impl<const LANES: usize> Sealed for Simd<$ty, LANES>
         where
@@ -307,9 +326,45 @@ macro_rules! impl_trait {
                 // Safety: `self` is an integer vector
                 unsafe { intrinsics::simd_reduce_xor(self) }
             }
+
+            #[inline]
+            fn swap_bytes(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_bswap(self) }
+            }
+
+            #[inline]
+            fn reverse_bits(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_bitreverse(self) }
+            }
+
+            #[inline]
+            fn leading_zeros(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_ctlz(self) }
+            }
+
+            #[inline]
+            fn trailing_zeros(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_cttz(self) }
+            }
+
+            #[inline]
+            fn leading_ones(self) -> Self {
+                use crate::simd::SimdUint;
+                self.cast::<$unsigned>().leading_ones().cast()
+            }
+
+            #[inline]
+            fn trailing_ones(self) -> Self {
+                use crate::simd::SimdUint;
+                self.cast::<$unsigned>().trailing_ones().cast()
+            }
         }
         )*
     }
 }
 
-impl_trait! { i8, i16, i32, i64, isize }
+impl_trait! { i8 (u8), i16 (u16), i32 (u32), i64 (u64), isize (usize) }

--- a/crates/core_simd/src/elements/uint.rs
+++ b/crates/core_simd/src/elements/uint.rs
@@ -71,6 +71,25 @@ pub trait SimdUint: Copy + Sealed {
 
     /// Returns the cumulative bitwise "xor" across the lanes of the vector.
     fn reduce_xor(self) -> Self::Scalar;
+
+    /// Reverses the byte order of each element.
+    fn swap_bytes(self) -> Self;
+
+    /// Reverses the order of bits in each elemnent.
+    /// The least significant bit becomes the most significant bit, second least-significant bit becomes second most-significant bit, etc.
+    fn reverse_bits(self) -> Self;
+
+    /// Returns the number of leading zeros in the binary representation of each element.
+    fn leading_zeros(self) -> Self;
+
+    /// Returns the number of trailing zeros in the binary representation of each element.
+    fn trailing_zeros(self) -> Self;
+
+    /// Returns the number of leading ones in the binary representation of each element.
+    fn leading_ones(self) -> Self;
+
+    /// Returns the number of trailing ones in the binary representation of each element.
+    fn trailing_ones(self) -> Self;
 }
 
 macro_rules! impl_trait {
@@ -147,6 +166,40 @@ macro_rules! impl_trait {
             fn reduce_xor(self) -> Self::Scalar {
                 // Safety: `self` is an integer vector
                 unsafe { intrinsics::simd_reduce_xor(self) }
+            }
+
+            #[inline]
+            fn swap_bytes(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_bswap(self) }
+            }
+
+            #[inline]
+            fn reverse_bits(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_bitreverse(self) }
+            }
+
+            #[inline]
+            fn leading_zeros(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_ctlz(self) }
+            }
+
+            #[inline]
+            fn trailing_zeros(self) -> Self {
+                // Safety: `self` is an integer vector
+                unsafe { intrinsics::simd_cttz(self) }
+            }
+
+            #[inline]
+            fn leading_ones(self) -> Self {
+                (!self).leading_zeros()
+            }
+
+            #[inline]
+            fn trailing_ones(self) -> Self {
+                (!self).trailing_zeros()
             }
         }
         )*

--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -160,4 +160,10 @@ extern "platform-intrinsic" {
 
     /// convert an exposed address back to a pointer
     pub(crate) fn simd_from_exposed_addr<T, U>(addr: T) -> U;
+
+    // Integer operations
+    pub(crate) fn simd_bswap<T>(x: T) -> T;
+    pub(crate) fn simd_bitreverse<T>(x: T) -> T;
+    pub(crate) fn simd_ctlz<T>(x: T) -> T;
+    pub(crate) fn simd_cttz<T>(x: T) -> T;
 }

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -193,6 +193,54 @@ macro_rules! impl_common_integer_tests {
                     Ok(())
                 });
             }
+
+            fn swap_bytes<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::swap_bytes,
+                    &$scalar::swap_bytes,
+                    &|_| true,
+                )
+            }
+
+            fn reverse_bits<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::reverse_bits,
+                    &$scalar::reverse_bits,
+                    &|_| true,
+                )
+            }
+
+            fn leading_zeros<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::leading_zeros,
+                    &|x| x.leading_zeros() as $scalar,
+                    &|_| true,
+                )
+            }
+
+            fn trailing_zeros<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::leading_zeros,
+                    &|x| x.trailing_zeros() as $scalar,
+                    &|_| true,
+                )
+            }
+
+            fn leading_ones<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::leading_ones,
+                    &|x| x.leading_ones() as $scalar,
+                    &|_| true,
+                )
+            }
+
+            fn trailing_ones<const LANES: usize>() {
+                test_helpers::test_unary_elementwise(
+                    &$vector::<LANES>::leading_ones,
+                    &|x| x.trailing_ones() as $scalar,
+                    &|_| true,
+                )
+            }
         }
     }
 }

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -220,7 +220,7 @@ macro_rules! impl_common_integer_tests {
 
             fn trailing_zeros<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
-                    &$vector::<LANES>::leading_zeros,
+                    &$vector::<LANES>::trailing_zeros,
                     &|x| x.trailing_zeros() as $scalar,
                     &|_| true,
                 )
@@ -236,7 +236,7 @@ macro_rules! impl_common_integer_tests {
 
             fn trailing_ones<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
-                    &$vector::<LANES>::leading_ones,
+                    &$vector::<LANES>::trailing_ones,
                     &|x| x.trailing_ones() as $scalar,
                     &|_| true,
                 )

--- a/crates/core_simd/tests/ops_macros.rs
+++ b/crates/core_simd/tests/ops_macros.rs
@@ -213,7 +213,7 @@ macro_rules! impl_common_integer_tests {
             fn leading_zeros<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
                     &$vector::<LANES>::leading_zeros,
-                    &|x| x.leading_zeros() as $scalar,
+                    &|x| x.leading_zeros() as _,
                     &|_| true,
                 )
             }
@@ -221,7 +221,7 @@ macro_rules! impl_common_integer_tests {
             fn trailing_zeros<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
                     &$vector::<LANES>::trailing_zeros,
-                    &|x| x.trailing_zeros() as $scalar,
+                    &|x| x.trailing_zeros() as _,
                     &|_| true,
                 )
             }
@@ -229,7 +229,7 @@ macro_rules! impl_common_integer_tests {
             fn leading_ones<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
                     &$vector::<LANES>::leading_ones,
-                    &|x| x.leading_ones() as $scalar,
+                    &|x| x.leading_ones() as _,
                     &|_| true,
                 )
             }
@@ -237,7 +237,7 @@ macro_rules! impl_common_integer_tests {
             fn trailing_ones<const LANES: usize>() {
                 test_helpers::test_unary_elementwise(
                     &$vector::<LANES>::trailing_ones,
-                    &|x| x.trailing_ones() as $scalar,
+                    &|x| x.trailing_ones() as _,
                     &|_| true,
                 )
             }

--- a/crates/core_simd/tests/to_bytes.rs
+++ b/crates/core_simd/tests/to_bytes.rs
@@ -7,8 +7,16 @@ use core_simd::simd::Simd;
 #[test]
 fn byte_convert() {
     let int = Simd::<u32, 2>::from_array([0xdeadbeef, 0x8badf00d]);
-    let bytes = int.to_ne_bytes();
-    assert_eq!(int[0].to_ne_bytes(), bytes[..4]);
-    assert_eq!(int[1].to_ne_bytes(), bytes[4..]);
-    assert_eq!(Simd::<u32, 2>::from_ne_bytes(bytes), int);
+    let ne_bytes = int.to_ne_bytes();
+    let be_bytes = int.to_be_bytes();
+    let le_bytes = int.to_le_bytes();
+    assert_eq!(int[0].to_ne_bytes(), ne_bytes[..4]);
+    assert_eq!(int[1].to_ne_bytes(), ne_bytes[4..]);
+    assert_eq!(int[0].to_be_bytes(), be_bytes[..4]);
+    assert_eq!(int[1].to_be_bytes(), be_bytes[4..]);
+    assert_eq!(int[0].to_le_bytes(), le_bytes[..4]);
+    assert_eq!(int[1].to_le_bytes(), le_bytes[4..]);
+    assert_eq!(Simd::<u32, 2>::from_ne_bytes(ne_bytes), int);
+    assert_eq!(Simd::<u32, 2>::from_be_bytes(be_bytes), int);
+    assert_eq!(Simd::<u32, 2>::from_le_bytes(le_bytes), int);
 }


### PR DESCRIPTION
~Pending rust-lang/rust#114266 and an `i16xN::trailing_zeros` bug that I hope is fixed by LLVM 15 17~

Good to go.