### PR TITLE
Remove `generic_const_exprs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         run: cross test --verbose --target=${{ matrix.target }} --release
 
   features:
-    name: "Check cargo features (${{ matrix.simd }} × ${{ matrix.features }})"
+    name: "Test cargo features (${{ matrix.simd }} × ${{ matrix.features }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -249,12 +249,8 @@ jobs:
         features:
           - ""
           - "--features std"
-          - "--features generic_const_exprs"
-          - "--features std --features generic_const_exprs"
           - "--features all_lane_counts"
-          - "--features all_lane_counts --features std"
-          - "--features all_lane_counts --features generic_const_exprs"
-          - "--features all_lane_counts --features std --features generic_const_exprs"
+          - "--all-features"
 
     steps:
       - uses: actions/checkout@v2
@@ -266,9 +262,9 @@ jobs:
         run: echo "CPU_FEATURE=$(lscpu | grep -o avx512[a-z]* | sed s/avx/+avx/ | tr '\n' ',' )" >> $GITHUB_ENV
       - name: Check build
         if: ${{ matrix.simd == '' }}
-        run: RUSTFLAGS="-Dwarnings" cargo check --all-targets --no-default-features ${{ matrix.features }}
+        run: RUSTFLAGS="-Dwarnings" cargo test --all-targets --no-default-features ${{ matrix.features }}
       - name: Check AVX
         if: ${{ matrix.simd == 'avx512' && contains(env.CPU_FEATURE, 'avx512') }}
         run: |
           echo "Found AVX features: $CPU_FEATURE"
-          RUSTFLAGS="-Dwarnings -Ctarget-feature=$CPU_FEATURE" cargo check --all-targets --no-default-features ${{ matrix.features }}
+          RUSTFLAGS="-Dwarnings -Ctarget-feature=$CPU_FEATURE" cargo test --all-targets --no-default-features ${{ matrix.features }}

--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 default = ["as_crate"]
 as_crate = []
 std = []
-generic_const_exprs = []
 all_lane_counts = []
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -14,8 +14,6 @@
     strict_provenance,
     ptr_metadata
 )]
-#![cfg_attr(feature = "generic_const_exprs", feature(generic_const_exprs))]
-#![cfg_attr(feature = "generic_const_exprs", allow(incomplete_features))]
 #![warn(missing_docs, clippy::missing_inline_in_public_items)] // basically all items, really
 #![deny(unsafe_op_in_unsafe_fn, clippy::undocumented_unsafe_blocks)]
 #![allow(internal_features)]

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -13,10 +13,7 @@
 mod mask_impl;
 
 mod to_bitmask;
-pub use to_bitmask::ToBitMask;
-
-#[cfg(feature = "generic_const_exprs")]
-pub use to_bitmask::{bitmask_len, ToBitMaskArray};
+pub use to_bitmask::{ToBitMask, ToBitMaskArray};
 
 use crate::simd::{intrinsics, LaneCount, Simd, SimdElement, SimdPartialEq, SupportedLaneCount};
 use core::cmp::Ordering;

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -119,7 +119,6 @@ where
         unsafe { Self(intrinsics::simd_bitmask(value), PhantomData) }
     }
 
-    #[cfg(feature = "generic_const_exprs")]
     #[inline]
     #[must_use = "method returns a new array and does not mutate the original value"]
     pub fn to_bitmask_array<const N: usize>(self) -> [u8; N] {
@@ -129,7 +128,6 @@ where
         unsafe { core::mem::transmute_copy(&self.0) }
     }
 
-    #[cfg(feature = "generic_const_exprs")]
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub fn from_bitmask_array<const N: usize>(bitmask: [u8; N]) -> Self {

--- a/crates/core_simd/src/masks/to_bitmask.rs
+++ b/crates/core_simd/src/masks/to_bitmask.rs
@@ -1,5 +1,6 @@
 use super::{mask_impl, Mask, MaskElement};
 use crate::simd::{LaneCount, SupportedLaneCount};
+use core::borrow::{Borrow, BorrowMut};
 
 mod sealed {
     pub trait Sealed {}
@@ -32,7 +33,15 @@ pub trait ToBitMask: Sealed {
 /// Each bit of the bitmask corresponds to a mask lane, starting with the LSB of the first byte.
 pub trait ToBitMaskArray: Sealed {
     /// The bitmask array.
-    type BitMaskArray;
+    type BitMaskArray: Copy
+        + Unpin
+        + Send
+        + Sync
+        + AsRef<[u8]>
+        + AsMut<[u8]>
+        + Borrow<[u8]>
+        + BorrowMut<[u8]>
+        + 'static;
 
     /// Converts a mask to a bitmask.
     fn to_bitmask_array(self) -> Self::BitMaskArray;

--- a/crates/core_simd/src/mod.rs
+++ b/crates/core_simd/src/mod.rs
@@ -3,9 +3,6 @@ mod swizzle;
 
 pub(crate) mod intrinsics;
 
-#[cfg(feature = "generic_const_exprs")]
-mod to_bytes;
-
 mod alias;
 mod cast;
 mod elements;
@@ -18,6 +15,7 @@ mod ops;
 mod ord;
 mod select;
 mod swizzle_dyn;
+mod to_bytes;
 mod vector;
 mod vendor;
 
@@ -37,5 +35,6 @@ pub mod simd {
     pub use crate::core_simd::ord::*;
     pub use crate::core_simd::swizzle::*;
     pub use crate::core_simd::swizzle_dyn::*;
+    pub use crate::core_simd::to_bytes::ToBytes;
     pub use crate::core_simd::vector::*;
 }

--- a/crates/core_simd/src/to_bytes.rs
+++ b/crates/core_simd/src/to_bytes.rs
@@ -42,38 +42,18 @@ macro_rules! swap_bytes {
 }
 
 macro_rules! impl_to_bytes {
-    { $ty:tt, $size:tt } => {
-        impl_to_bytes! { $ty, $size * 1 }
-        impl_to_bytes! { $ty, $size * 2 }
-        impl_to_bytes! { $ty, $size * 4 }
-        impl_to_bytes! { $ty, $size * 8 }
-        impl_to_bytes! { $ty, $size * 16 }
-        impl_to_bytes! { $ty, $size * 32 }
-        impl_to_bytes! { $ty, $size * 64 }
-    };
+    { $ty:tt, 1  } => { impl_to_bytes! { $ty, 1  * [1, 2, 4, 8, 16, 32, 64] } };
+    { $ty:tt, 2  } => { impl_to_bytes! { $ty, 2  * [1, 2, 4, 8, 16, 32] } };
+    { $ty:tt, 4  } => { impl_to_bytes! { $ty, 4  * [1, 2, 4, 8, 16] } };
+    { $ty:tt, 8  } => { impl_to_bytes! { $ty, 8  * [1, 2, 4, 8] } };
+    { $ty:tt, 16 } => { impl_to_bytes! { $ty, 16 * [1, 2, 4] } };
+    { $ty:tt, 32 } => { impl_to_bytes! { $ty, 32 * [1, 2] } };
+    { $ty:tt, 64 } => { impl_to_bytes! { $ty, 64 * [1] } };
 
-    // multiply element size by number of elements
-    { $ty:tt, 1 * $elems:literal } => { impl_to_bytes! { @impl [$ty; $elems], $elems } };
-    { $ty:tt, $size:literal * 1 } => { impl_to_bytes! { @impl [$ty; 1], $size } };
-    { $ty:tt, 2 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 4  } };
-    { $ty:tt, 2 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 8  } };
-    { $ty:tt, 2 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 16 } };
-    { $ty:tt, 2 * 16 } => { impl_to_bytes! { @impl [$ty; 16], 32 } };
-    { $ty:tt, 2 * 32 } => { impl_to_bytes! { @impl [$ty; 32], 64 } };
-    { $ty:tt, 4 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 8  } };
-    { $ty:tt, 4 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 16 } };
-    { $ty:tt, 4 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 32 } };
-    { $ty:tt, 4 * 16 } => { impl_to_bytes! { @impl [$ty; 16], 64 } };
-    { $ty:tt, 8 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 16 } };
-    { $ty:tt, 8 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 32 } };
-    { $ty:tt, 8 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 64 } };
-
-    // unsupported number of lanes
-    { $ty:ty, $a:literal * $b:literal } => { };
-
-    { @impl [$ty:tt; $elem:literal], $bytes:literal } => {
-        impl ToBytes for Simd<$ty, $elem> {
-            type Bytes = Simd<u8, $bytes>;
+    { $ty:tt, $size:literal * [$($elems:literal),*] } => {
+        $(
+        impl ToBytes for Simd<$ty, $elems> {
+            type Bytes = Simd<u8, { $size * $elems }>;
 
             #[inline]
             fn to_ne_bytes(self) -> Self::Bytes {
@@ -123,6 +103,7 @@ macro_rules! impl_to_bytes {
                 }
             }
         }
+        )*
     }
 }
 

--- a/crates/core_simd/src/to_bytes.rs
+++ b/crates/core_simd/src/to_bytes.rs
@@ -10,7 +10,14 @@ use sealed::Sealed;
 /// Convert SIMD vectors to vectors of bytes
 pub trait ToBytes: Sealed {
     /// This type, reinterpreted as bytes.
-    type Bytes;
+    type Bytes: Copy
+        + Unpin
+        + Send
+        + Sync
+        + AsRef<[u8]>
+        + AsMut<[u8]>
+        + SimdUint<Scalar = u8>
+        + 'static;
 
     /// Return the memory representation of this integer as a byte array in native byte
     /// order.

--- a/crates/core_simd/src/to_bytes.rs
+++ b/crates/core_simd/src/to_bytes.rs
@@ -1,72 +1,126 @@
-use crate::simd::SimdUint;
+use crate::simd::{LaneCount, Simd, SimdElement, SimdFloat, SimdInt, SimdUint, SupportedLaneCount};
+
+mod sealed {
+    use super::*;
+    pub trait Sealed {}
+    impl<T: SimdElement, const N: usize> Sealed for Simd<T, N> where LaneCount<N>: SupportedLaneCount {}
+}
+use sealed::Sealed;
+
+/// Convert SIMD vectors to vectors of bytes
+pub trait ToBytes: Sealed {
+    /// This type, reinterpreted as bytes.
+    type Bytes;
+
+    /// Return the memory representation of this integer as a byte array in native byte
+    /// order.
+    fn to_ne_bytes(self) -> Self::Bytes;
+
+    /// Return the memory representation of this integer as a byte array in big-endian
+    /// (network) byte order.
+    fn to_be_bytes(self) -> Self::Bytes;
+
+    /// Return the memory representation of this integer as a byte array in little-endian
+    /// byte order.
+    fn to_le_bytes(self) -> Self::Bytes;
+
+    /// Create a native endian integer value from its memory representation as a byte array
+    /// in native endianness.
+    fn from_ne_bytes(bytes: Self::Bytes) -> Self;
+
+    /// Create an integer value from its representation as a byte array in big endian.
+    fn from_be_bytes(bytes: Self::Bytes) -> Self;
+
+    /// Create an integer value from its representation as a byte array in little endian.
+    fn from_le_bytes(bytes: Self::Bytes) -> Self;
+}
+
+macro_rules! swap_bytes {
+    { f32, $x:expr } => { Simd::from_bits($x.to_bits().swap_bytes()) };
+    { f64, $x:expr } => { Simd::from_bits($x.to_bits().swap_bytes()) };
+    { $ty:ty, $x:expr } => { $x.swap_bytes() }
+}
 
 macro_rules! impl_to_bytes {
-    { $ty:ty, $size:literal } => {
-        impl<const LANES: usize> crate::simd::Simd<$ty, LANES>
-        where
-            crate::simd::LaneCount<LANES>: crate::simd::SupportedLaneCount,
-            crate::simd::LaneCount<{{ $size * LANES }}>: crate::simd::SupportedLaneCount,
-        {
-            /// Return the memory representation of this integer as a byte array in native byte
-            /// order.
+    { $ty:tt, $size:tt } => {
+        impl_to_bytes! { $ty, $size * 1 }
+        impl_to_bytes! { $ty, $size * 2 }
+        impl_to_bytes! { $ty, $size * 4 }
+        impl_to_bytes! { $ty, $size * 8 }
+        impl_to_bytes! { $ty, $size * 16 }
+        impl_to_bytes! { $ty, $size * 32 }
+        impl_to_bytes! { $ty, $size * 64 }
+    };
+
+    // multiply element size by number of elements
+    { $ty:tt, 1 * $elems:literal } => { impl_to_bytes! { @impl [$ty; $elems], $elems } };
+    { $ty:tt, $size:literal * 1 } => { impl_to_bytes! { @impl [$ty; 1], $size } };
+    { $ty:tt, 2 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 4  } };
+    { $ty:tt, 2 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 8  } };
+    { $ty:tt, 2 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 16 } };
+    { $ty:tt, 2 * 16 } => { impl_to_bytes! { @impl [$ty; 16], 32 } };
+    { $ty:tt, 2 * 32 } => { impl_to_bytes! { @impl [$ty; 32], 64 } };
+    { $ty:tt, 4 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 8  } };
+    { $ty:tt, 4 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 16 } };
+    { $ty:tt, 4 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 32 } };
+    { $ty:tt, 4 * 16 } => { impl_to_bytes! { @impl [$ty; 16], 64 } };
+    { $ty:tt, 8 * 2  } => { impl_to_bytes! { @impl [$ty; 2], 16 } };
+    { $ty:tt, 8 * 4  } => { impl_to_bytes! { @impl [$ty; 4], 32 } };
+    { $ty:tt, 8 * 8  } => { impl_to_bytes! { @impl [$ty; 8], 64 } };
+
+    // unsupported number of lanes
+    { $ty:ty, $a:literal * $b:literal } => { };
+
+    { @impl [$ty:tt; $elem:literal], $bytes:literal } => {
+        impl ToBytes for Simd<$ty, $elem> {
+            type Bytes = Simd<u8, $bytes>;
+
             #[inline]
-            pub fn to_ne_bytes(self) -> crate::simd::Simd<u8, {{ $size * LANES }}> {
+            fn to_ne_bytes(self) -> Self::Bytes {
                 // Safety: transmuting between vectors is safe
-                unsafe { core::mem::transmute_copy(&self) }
+                unsafe { core::mem::transmute(self) }
             }
 
-            /// Return the memory representation of this integer as a byte array in big-endian
-            /// (network) byte order.
             #[inline]
-            pub fn to_be_bytes(self) -> crate::simd::Simd<u8, {{ $size * LANES }}> {
-                let bytes = self.to_ne_bytes();
+            fn to_be_bytes(mut self) -> Self::Bytes {
+                if !cfg!(target_endian = "big") {
+                    self = swap_bytes!($ty, self);
+                }
+                self.to_ne_bytes()
+            }
+
+            #[inline]
+            fn to_le_bytes(mut self) -> Self::Bytes {
+                if !cfg!(target_endian = "little") {
+                    self = swap_bytes!($ty, self);
+                }
+                self.to_ne_bytes()
+            }
+
+            #[inline]
+            fn from_ne_bytes(bytes: Self::Bytes) -> Self {
+                // Safety: transmuting between vectors is safe
+                unsafe { core::mem::transmute(bytes) }
+            }
+
+            #[inline]
+            fn from_be_bytes(bytes: Self::Bytes) -> Self {
+                let ret = Self::from_ne_bytes(bytes);
                 if cfg!(target_endian = "big") {
-                    bytes
+                    ret
                 } else {
-                    bytes.swap_bytes()
+                    swap_bytes!($ty, ret)
                 }
             }
 
-            /// Return the memory representation of this integer as a byte array in little-endian
-            /// byte order.
             #[inline]
-            pub fn to_le_bytes(self) -> crate::simd::Simd<u8, {{ $size * LANES }}> {
-                let bytes = self.to_ne_bytes();
+            fn from_le_bytes(bytes: Self::Bytes) -> Self {
+                let ret = Self::from_ne_bytes(bytes);
                 if cfg!(target_endian = "little") {
-                    bytes
+                    ret
                 } else {
-                    bytes.swap_bytes()
+                    swap_bytes!($ty, ret)
                 }
-            }
-
-            /// Create a native endian integer value from its memory representation as a byte array
-            /// in native endianness.
-            #[inline]
-            pub fn from_ne_bytes(bytes: crate::simd::Simd<u8, {{ $size * LANES }}>) -> Self {
-                // Safety: transmuting between vectors is safe
-                unsafe { core::mem::transmute_copy(&bytes) }
-            }
-
-            /// Create an integer value from its representation as a byte array in big endian.
-            #[inline]
-            pub fn from_be_bytes(bytes: crate::simd::Simd<u8, {{ $size * LANES }}>) -> Self {
-                let bytes = if cfg!(target_endian = "big") {
-                    bytes
-                } else {
-                    bytes.swap_bytes()
-                };
-                Self::from_ne_bytes(bytes)
-            }
-
-            /// Create an integer value from its representation as a byte array in little endian.
-            #[inline]
-            pub fn from_le_bytes(bytes: crate::simd::Simd<u8, {{ $size * LANES }}>) -> Self {
-                let bytes = if cfg!(target_endian = "little") {
-                    bytes
-                } else {
-                    bytes.swap_bytes()
-                };
-                Self::from_ne_bytes(bytes)
             }
         }
     }
@@ -89,3 +143,6 @@ impl_to_bytes! { i64, 8 }
 impl_to_bytes! { isize, 4 }
 #[cfg(target_pointer_width = "64")]
 impl_to_bytes! { isize, 8 }
+
+impl_to_bytes! { f32, 4 }
+impl_to_bytes! { f64, 8 }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -125,7 +125,6 @@ macro_rules! test_mask_api {
                 cast_impl::<isize>();
             }
 
-            #[cfg(feature = "generic_const_exprs")]
             #[test]
             fn roundtrip_bitmask_array_conversion() {
                 use core_simd::simd::ToBitMaskArray;

--- a/crates/core_simd/tests/to_bytes.rs
+++ b/crates/core_simd/tests/to_bytes.rs
@@ -1,8 +1,6 @@
-#![feature(portable_simd, generic_const_exprs, adt_const_params)]
-#![allow(incomplete_features)]
-#![cfg(feature = "generic_const_exprs")]
+#![feature(portable_simd)]
 
-use core_simd::simd::Simd;
+use core_simd::simd::{Simd, ToBytes};
 
 #[test]
 fn byte_convert() {


### PR DESCRIPTION
Inspired by the errors in #367 (caused by rust-lang/rust#116320) I've removed all instances of `generic_const_exprs`.

For `ToBitMaskArray`, this was straightforward, simply use an associated type instead of an associated const.  For the various `to_bytes` functions, this was more complicated.  I now implemented a `ToBytes` trait over every individual vector type.  In the future when const generics are more powerful, I'd hope this can be implemented generically.

This effectively upgrades these functions to nightly, as they're currently disabled on core.