### PR TITLE
Eliminate use of `#[cfg_attr(not(doc), repr(transparent))]`

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -88,7 +88,7 @@ impl_element! { isize }
 /// The layout of this type is unspecified, and may change between platforms
 /// and/or Rust versions, and code should not assume that it is equivalent to
 /// `[T; LANES]`.
-#[cfg_attr(not(doc), repr(transparent))] // work around https://github.com/rust-lang/rust/issues/90435
+#[repr(transparent)]
 pub struct Mask<T, const LANES: usize>(mask_impl::Mask<T, LANES>)
 where
     T: MaskElement,


### PR DESCRIPTION
Context: https://github.com/rust-lang/rust/pull/116743. This PR is extracted from there by advice of https://github.com/rust-lang/rust/pull/116743#issuecomment-1763178813.