### PR TITLE
Rename "lane" to "element"

### DIFF
--- a/crates/core_simd/examples/matrix_inversion.rs
+++ b/crates/core_simd/examples/matrix_inversion.rs
@@ -179,58 +179,58 @@ pub fn simd_inv4x4(m: Matrix4x4) -> Option<Matrix4x4> {
     let row2 = simd_swizzle!(tmp, row3, SHUFFLE02);
     let row3 = simd_swizzle!(row3, tmp, SHUFFLE13);
 
-    let tmp = (row2 * row3).reverse().rotate_lanes_right::<2>();
+    let tmp = (row2 * row3).reverse().rotate_elements_right::<2>();
     let minor0 = row1 * tmp;
     let minor1 = row0 * tmp;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
     let minor0 = (row1 * tmp) - minor0;
     let minor1 = (row0 * tmp) - minor1;
-    let minor1 = minor1.rotate_lanes_right::<2>();
+    let minor1 = minor1.rotate_elements_right::<2>();
 
-    let tmp = (row1 * row2).reverse().rotate_lanes_right::<2>();
+    let tmp = (row1 * row2).reverse().rotate_elements_right::<2>();
     let minor0 = (row3 * tmp) + minor0;
     let minor3 = row0 * tmp;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
 
     let minor0 = minor0 - row3 * tmp;
     let minor3 = row0 * tmp - minor3;
-    let minor3 = minor3.rotate_lanes_right::<2>();
+    let minor3 = minor3.rotate_elements_right::<2>();
 
-    let tmp = (row3 * row1.rotate_lanes_right::<2>())
+    let tmp = (row3 * row1.rotate_elements_right::<2>())
         .reverse()
-        .rotate_lanes_right::<2>();
-    let row2 = row2.rotate_lanes_right::<2>();
+        .rotate_elements_right::<2>();
+    let row2 = row2.rotate_elements_right::<2>();
     let minor0 = row2 * tmp + minor0;
     let minor2 = row0 * tmp;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
     let minor0 = minor0 - row2 * tmp;
     let minor2 = row0 * tmp - minor2;
-    let minor2 = minor2.rotate_lanes_right::<2>();
+    let minor2 = minor2.rotate_elements_right::<2>();
 
-    let tmp = (row0 * row1).reverse().rotate_lanes_right::<2>();
+    let tmp = (row0 * row1).reverse().rotate_elements_right::<2>();
     let minor2 = minor2 + row3 * tmp;
     let minor3 = row2 * tmp - minor3;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
     let minor2 = row3 * tmp - minor2;
     let minor3 = minor3 - row2 * tmp;
 
-    let tmp = (row0 * row3).reverse().rotate_lanes_right::<2>();
+    let tmp = (row0 * row3).reverse().rotate_elements_right::<2>();
     let minor1 = minor1 - row2 * tmp;
     let minor2 = row1 * tmp + minor2;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
     let minor1 = row2 * tmp + minor1;
     let minor2 = minor2 - row1 * tmp;
 
-    let tmp = (row0 * row2).reverse().rotate_lanes_right::<2>();
+    let tmp = (row0 * row2).reverse().rotate_elements_right::<2>();
     let minor1 = row3 * tmp + minor1;
     let minor3 = minor3 - row1 * tmp;
-    let tmp = tmp.rotate_lanes_right::<2>();
+    let tmp = tmp.rotate_elements_right::<2>();
     let minor1 = minor1 - row3 * tmp;
     let minor3 = row1 * tmp + minor3;
 
     let det = row0 * minor0;
-    let det = det.rotate_lanes_right::<2>() + det;
-    let det = det.reverse().rotate_lanes_right::<2>() + det;
+    let det = det.rotate_elements_right::<2>() + det;
+    let det = det.reverse().rotate_elements_right::<2>() + det;
 
     if det.reduce_sum() == 0. {
         return None;

--- a/crates/core_simd/src/fmt.rs
+++ b/crates/core_simd/src/fmt.rs
@@ -1,9 +1,9 @@
 use crate::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
 use core::fmt;
 
-impl<T, const LANES: usize> fmt::Debug for Simd<T, LANES>
+impl<T, const N: usize> fmt::Debug for Simd<T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
     T: SimdElement + fmt::Debug,
 {
     /// A `Simd<T, N>` has a debug format like the one for `[T]`:

--- a/crates/core_simd/src/iter.rs
+++ b/crates/core_simd/src/iter.rs
@@ -6,9 +6,9 @@ use core::{
 
 macro_rules! impl_traits {
     { $type:ty } => {
-        impl<const LANES: usize> Sum<Self> for Simd<$type, LANES>
+        impl<const N: usize> Sum<Self> for Simd<$type, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -16,9 +16,9 @@ macro_rules! impl_traits {
             }
         }
 
-        impl<const LANES: usize> Product<Self> for Simd<$type, LANES>
+        impl<const N: usize> Product<Self> for Simd<$type, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -26,9 +26,9 @@ macro_rules! impl_traits {
             }
         }
 
-        impl<'a, const LANES: usize> Sum<&'a Self> for Simd<$type, LANES>
+        impl<'a, const N: usize> Sum<&'a Self> for Simd<$type, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
@@ -36,9 +36,9 @@ macro_rules! impl_traits {
             }
         }
 
-        impl<'a, const LANES: usize> Product<&'a Self> for Simd<$type, LANES>
+        impl<'a, const N: usize> Product<&'a Self> for Simd<$type, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {

--- a/crates/core_simd/src/lane_count.rs
+++ b/crates/core_simd/src/lane_count.rs
@@ -4,11 +4,11 @@ mod sealed {
 use sealed::Sealed;
 
 /// Specifies the number of lanes in a SIMD vector as a type.
-pub struct LaneCount<const LANES: usize>;
+pub struct LaneCount<const N: usize>;
 
-impl<const LANES: usize> LaneCount<LANES> {
+impl<const N: usize> LaneCount<N> {
     /// The number of bytes in a bitmask with this many lanes.
-    pub const BITMASK_LEN: usize = (LANES + 7) / 8;
+    pub const BITMASK_LEN: usize = (N + 7) / 8;
 }
 
 /// Statically guarantees that a lane count is marked as supported.
@@ -21,7 +21,7 @@ pub trait SupportedLaneCount: Sealed {
     type BitMask: Copy + Default + AsRef<[u8]> + AsMut<[u8]>;
 }
 
-impl<const LANES: usize> Sealed for LaneCount<LANES> {}
+impl<const N: usize> Sealed for LaneCount<N> {}
 
 macro_rules! supported_lane_count {
     ($($lanes:literal),+) => {

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -1,4 +1,4 @@
-//! Types and traits associated with masking lanes of vectors.
+//! Types and traits associated with masking elements of vectors.
 //! Types representing
 #![allow(non_camel_case_types)]
 
@@ -82,7 +82,7 @@ impl_element! { isize }
 
 /// A SIMD vector mask for `LANES` elements of width specified by `Element`.
 ///
-/// Masks represent boolean inclusion/exclusion on a per-lane basis.
+/// Masks represent boolean inclusion/exclusion on a per-element basis.
 ///
 /// The layout of this type is unspecified, and may change between platforms
 /// and/or Rust versions, and code should not assume that it is equivalent to
@@ -116,7 +116,7 @@ where
     T: MaskElement,
     LaneCount<LANES>: SupportedLaneCount,
 {
-    /// Construct a mask by setting all lanes to the given value.
+    /// Construct a mask by setting all elements to the given value.
     #[inline]
     pub fn splat(value: bool) -> Self {
         Self(mask_impl::Mask::splat(value))
@@ -163,7 +163,7 @@ where
     /// represents `true`.
     ///
     /// # Safety
-    /// All lanes must be either 0 or -1.
+    /// All elements must be either 0 or -1.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub unsafe fn from_int_unchecked(value: Simd<T, LANES>) -> Self {
@@ -175,7 +175,7 @@ where
     /// represents `true`.
     ///
     /// # Panics
-    /// Panics if any lane is not 0 or -1.
+    /// Panics if any element is not 0 or -1.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     #[track_caller]
@@ -193,71 +193,71 @@ where
         self.0.to_int()
     }
 
-    /// Converts the mask to a mask of any other lane size.
+    /// Converts the mask to a mask of any other element size.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub fn cast<U: MaskElement>(self) -> Mask<U, LANES> {
         Mask(self.0.convert())
     }
 
-    /// Tests the value of the specified lane.
+    /// Tests the value of the specified element.
     ///
     /// # Safety
-    /// `lane` must be less than `LANES`.
+    /// `element` must be less than `self.len()`.
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
-    pub unsafe fn test_unchecked(&self, lane: usize) -> bool {
+    pub unsafe fn test_unchecked(&self, index: usize) -> bool {
         // Safety: the caller must confirm this invariant
-        unsafe { self.0.test_unchecked(lane) }
+        unsafe { self.0.test_unchecked(index) }
     }
 
-    /// Tests the value of the specified lane.
+    /// Tests the value of the specified element.
     ///
     /// # Panics
-    /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
+    /// Panics if `index` is greater than or equal to the number of elements in the vector.
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
     #[track_caller]
-    pub fn test(&self, lane: usize) -> bool {
-        assert!(lane < LANES, "lane index out of range");
-        // Safety: the lane index has been checked
-        unsafe { self.test_unchecked(lane) }
+    pub fn test(&self, index: usize) -> bool {
+        assert!(index < LANES, "element index out of range");
+        // Safety: the element index has been checked
+        unsafe { self.test_unchecked(index) }
     }
 
-    /// Sets the value of the specified lane.
+    /// Sets the value of the specified element.
     ///
     /// # Safety
-    /// `lane` must be less than `LANES`.
+    /// `index` must be less than `self.len()`.
     #[inline]
-    pub unsafe fn set_unchecked(&mut self, lane: usize, value: bool) {
+    pub unsafe fn set_unchecked(&mut self, index: usize, value: bool) {
         // Safety: the caller must confirm this invariant
         unsafe {
-            self.0.set_unchecked(lane, value);
+            self.0.set_unchecked(index, value);
         }
     }
 
-    /// Sets the value of the specified lane.
+    /// Sets the value of the specified element.
     ///
     /// # Panics
-    /// Panics if `lane` is greater than or equal to the number of lanes in the vector.
+    /// Panics if `index` is greater than or equal to the number of elements in the vector.
     #[inline]
     #[track_caller]
-    pub fn set(&mut self, lane: usize, value: bool) {
-        assert!(lane < LANES, "lane index out of range");
-        // Safety: the lane index has been checked
+    pub fn set(&mut self, index: usize, value: bool) {
+        assert!(index < LANES, "element index out of range");
+        // Safety: the element index has been checked
         unsafe {
-            self.set_unchecked(lane, value);
+            self.set_unchecked(index, value);
         }
     }
 
-    /// Returns true if any lane is set, or false otherwise.
+    /// Returns true if any element is set, or false otherwise.
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
     pub fn any(self) -> bool {
         self.0.any()
     }
 
-    /// Returns true if all lanes are set, or false otherwise.
+    /// Returns true if all elements are set, or false otherwise.
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
     pub fn all(self) -> bool {
@@ -294,7 +294,7 @@ where
     LaneCount<LANES>: SupportedLaneCount,
 {
     #[inline]
-    #[must_use = "method returns a defaulted mask with all lanes set to false (0)"]
+    #[must_use = "method returns a defaulted mask with all elements set to false (0)"]
     fn default() -> Self {
         Self::splat(false)
     }
@@ -332,7 +332,7 @@ where
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list()
-            .entries((0..LANES).map(|lane| self.test(lane)))
+            .entries((0..LANES).map(|i| self.test(i)))
             .finish()
     }
 }

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -202,7 +202,7 @@ where
     /// Tests the value of the specified element.
     ///
     /// # Safety
-    /// `element` must be less than `self.len()`.
+    /// `index` must be less than `self.len()`.
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
     pub unsafe fn test_unchecked(&self, index: usize) -> bool {

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -121,8 +121,8 @@ where
 
     #[inline]
     #[must_use = "method returns a new array and does not mutate the original value"]
-    pub fn to_bitmask_array<const N: usize>(self) -> [u8; N] {
-        assert!(core::mem::size_of::<Self>() == N);
+    pub fn to_bitmask_array<const M: usize>(self) -> [u8; M] {
+        assert!(core::mem::size_of::<Self>() == M);
 
         // Safety: converting an integer to an array of bytes of the same size is safe
         unsafe { core::mem::transmute_copy(&self.0) }
@@ -130,8 +130,8 @@ where
 
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub fn from_bitmask_array<const N: usize>(bitmask: [u8; N]) -> Self {
-        assert!(core::mem::size_of::<Self>() == N);
+    pub fn from_bitmask_array<const M: usize>(bitmask: [u8; M]) -> Self {
+        assert!(core::mem::size_of::<Self>() == M);
 
         // Safety: converting an array of bytes to an integer of the same size is safe
         Self(unsafe { core::mem::transmute_copy(&bitmask) }, PhantomData)

--- a/crates/core_simd/src/masks/to_bitmask.rs
+++ b/crates/core_simd/src/masks/to_bitmask.rs
@@ -7,10 +7,10 @@ mod sealed {
 }
 pub use sealed::Sealed;
 
-impl<T, const LANES: usize> Sealed for Mask<T, LANES>
+impl<T, const N: usize> Sealed for Mask<T, N>
 where
     T: MaskElement,
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
 }
 

--- a/crates/core_simd/src/masks/to_bitmask.rs
+++ b/crates/core_simd/src/masks/to_bitmask.rs
@@ -16,7 +16,7 @@ where
 
 /// Converts masks to and from integer bitmasks.
 ///
-/// Each bit of the bitmask corresponds to a mask lane, starting with the LSB.
+/// Each bit of the bitmask corresponds to a mask element, starting with the LSB.
 pub trait ToBitMask: Sealed {
     /// The integer bitmask type.
     type BitMask;
@@ -30,7 +30,7 @@ pub trait ToBitMask: Sealed {
 
 /// Converts masks to and from byte array bitmasks.
 ///
-/// Each bit of the bitmask corresponds to a mask lane, starting with the LSB of the first byte.
+/// Each bit of the bitmask corresponds to a mask element, starting with the LSB of the first byte.
 pub trait ToBitMaskArray: Sealed {
     /// The bitmask array.
     type BitMaskArray: Copy

--- a/crates/core_simd/src/ops.rs
+++ b/crates/core_simd/src/ops.rs
@@ -9,10 +9,10 @@ mod deref;
 mod shift_scalar;
 mod unary;
 
-impl<I, T, const LANES: usize> core::ops::Index<I> for Simd<T, LANES>
+impl<I, T, const N: usize> core::ops::Index<I> for Simd<T, N>
 where
     T: SimdElement,
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
     I: core::slice::SliceIndex<[T]>,
 {
     type Output = I::Output;
@@ -22,10 +22,10 @@ where
     }
 }
 
-impl<I, T, const LANES: usize> core::ops::IndexMut<I> for Simd<T, LANES>
+impl<I, T, const N: usize> core::ops::IndexMut<I> for Simd<T, N>
 where
     T: SimdElement,
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
     I: core::slice::SliceIndex<[T]>,
 {
     #[inline]

--- a/crates/core_simd/src/ops/assign.rs
+++ b/crates/core_simd/src/ops/assign.rs
@@ -8,7 +8,7 @@ use core::ops::{ShlAssign, ShrAssign}; // non-commutative bit binary op-assignme
 // Arithmetic
 
 macro_rules! assign_ops {
-    ($(impl<T, U, const LANES: usize> $assignTrait:ident<U> for Simd<T, LANES>
+    ($(impl<T, U, const N: usize> $assignTrait:ident<U> for Simd<T, N>
         where
             Self: $trait:ident,
         {
@@ -16,11 +16,11 @@ macro_rules! assign_ops {
                 $call:ident
             }
         })*) => {
-        $(impl<T, U, const LANES: usize> $assignTrait<U> for Simd<T, LANES>
+        $(impl<T, U, const N: usize> $assignTrait<U> for Simd<T, N>
         where
             Self: $trait<U, Output = Self>,
             T: SimdElement,
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn $assign_call(&mut self, rhs: U) {
@@ -32,7 +32,7 @@ macro_rules! assign_ops {
 
 assign_ops! {
     // Arithmetic
-    impl<T, U, const LANES: usize> AddAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> AddAssign<U> for Simd<T, N>
     where
         Self: Add,
     {
@@ -41,7 +41,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> MulAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> MulAssign<U> for Simd<T, N>
     where
         Self: Mul,
     {
@@ -50,7 +50,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> SubAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> SubAssign<U> for Simd<T, N>
     where
         Self: Sub,
     {
@@ -59,7 +59,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> DivAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> DivAssign<U> for Simd<T, N>
     where
         Self: Div,
     {
@@ -67,7 +67,7 @@ assign_ops! {
             div
         }
     }
-    impl<T, U, const LANES: usize> RemAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> RemAssign<U> for Simd<T, N>
     where
         Self: Rem,
     {
@@ -77,7 +77,7 @@ assign_ops! {
     }
 
     // Bitops
-    impl<T, U, const LANES: usize> BitAndAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> BitAndAssign<U> for Simd<T, N>
     where
         Self: BitAnd,
     {
@@ -86,7 +86,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> BitOrAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> BitOrAssign<U> for Simd<T, N>
     where
         Self: BitOr,
     {
@@ -95,7 +95,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> BitXorAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> BitXorAssign<U> for Simd<T, N>
     where
         Self: BitXor,
     {
@@ -104,7 +104,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> ShlAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> ShlAssign<U> for Simd<T, N>
     where
         Self: Shl,
     {
@@ -113,7 +113,7 @@ assign_ops! {
         }
     }
 
-    impl<T, U, const LANES: usize> ShrAssign<U> for Simd<T, LANES>
+    impl<T, U, const N: usize> ShrAssign<U> for Simd<T, N>
     where
         Self: Shr,
     {

--- a/crates/core_simd/src/ops/deref.rs
+++ b/crates/core_simd/src/ops/deref.rs
@@ -5,16 +5,16 @@
 use super::*;
 
 macro_rules! deref_lhs {
-    (impl<T, const LANES: usize> $trait:ident for $simd:ty {
+    (impl<T, const N: usize> $trait:ident for $simd:ty {
             fn $call:ident
         }) => {
-        impl<T, const LANES: usize> $trait<$simd> for &$simd
+        impl<T, const N: usize> $trait<$simd> for &$simd
         where
             T: SimdElement,
             $simd: $trait<$simd, Output = $simd>,
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
-            type Output = Simd<T, LANES>;
+            type Output = Simd<T, N>;
 
             #[inline]
             #[must_use = "operator returns a new vector without mutating the inputs"]
@@ -26,16 +26,16 @@ macro_rules! deref_lhs {
 }
 
 macro_rules! deref_rhs {
-    (impl<T, const LANES: usize> $trait:ident for $simd:ty {
+    (impl<T, const N: usize> $trait:ident for $simd:ty {
             fn $call:ident
         }) => {
-        impl<T, const LANES: usize> $trait<&$simd> for $simd
+        impl<T, const N: usize> $trait<&$simd> for $simd
         where
             T: SimdElement,
             $simd: $trait<$simd, Output = $simd>,
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
-            type Output = Simd<T, LANES>;
+            type Output = Simd<T, N>;
 
             #[inline]
             #[must_use = "operator returns a new vector without mutating the inputs"]
@@ -47,25 +47,25 @@ macro_rules! deref_rhs {
 }
 
 macro_rules! deref_ops {
-    ($(impl<T, const LANES: usize> $trait:ident for $simd:ty {
+    ($(impl<T, const N: usize> $trait:ident for $simd:ty {
             fn $call:ident
         })*) => {
         $(
             deref_rhs! {
-                impl<T, const LANES: usize> $trait for $simd {
+                impl<T, const N: usize> $trait for $simd {
                     fn $call
                 }
             }
             deref_lhs! {
-                impl<T, const LANES: usize> $trait for $simd {
+                impl<T, const N: usize> $trait for $simd {
                     fn $call
                 }
             }
-            impl<'lhs, 'rhs, T, const LANES: usize> $trait<&'rhs $simd> for &'lhs $simd
+            impl<'lhs, 'rhs, T, const N: usize> $trait<&'rhs $simd> for &'lhs $simd
             where
                 T: SimdElement,
                 $simd: $trait<$simd, Output = $simd>,
-                LaneCount<LANES>: SupportedLaneCount,
+                LaneCount<N>: SupportedLaneCount,
             {
                 type Output = $simd;
 
@@ -81,44 +81,44 @@ macro_rules! deref_ops {
 
 deref_ops! {
     // Arithmetic
-    impl<T, const LANES: usize> Add for Simd<T, LANES> {
+    impl<T, const N: usize> Add for Simd<T, N> {
         fn add
     }
 
-    impl<T, const LANES: usize> Mul for Simd<T, LANES> {
+    impl<T, const N: usize> Mul for Simd<T, N> {
         fn mul
     }
 
-    impl<T, const LANES: usize> Sub for Simd<T, LANES> {
+    impl<T, const N: usize> Sub for Simd<T, N> {
         fn sub
     }
 
-    impl<T, const LANES: usize> Div for Simd<T, LANES> {
+    impl<T, const N: usize> Div for Simd<T, N> {
         fn div
     }
 
-    impl<T, const LANES: usize> Rem for Simd<T, LANES> {
+    impl<T, const N: usize> Rem for Simd<T, N> {
         fn rem
     }
 
     // Bitops
-    impl<T, const LANES: usize> BitAnd for Simd<T, LANES> {
+    impl<T, const N: usize> BitAnd for Simd<T, N> {
         fn bitand
     }
 
-    impl<T, const LANES: usize> BitOr for Simd<T, LANES> {
+    impl<T, const N: usize> BitOr for Simd<T, N> {
         fn bitor
     }
 
-    impl<T, const LANES: usize> BitXor for Simd<T, LANES> {
+    impl<T, const N: usize> BitXor for Simd<T, N> {
         fn bitxor
     }
 
-    impl<T, const LANES: usize> Shl for Simd<T, LANES> {
+    impl<T, const N: usize> Shl for Simd<T, N> {
         fn shl
     }
 
-    impl<T, const LANES: usize> Shr for Simd<T, LANES> {
+    impl<T, const N: usize> Shr for Simd<T, N> {
         fn shr
     }
 }

--- a/crates/core_simd/src/ops/unary.rs
+++ b/crates/core_simd/src/ops/unary.rs
@@ -3,11 +3,11 @@ use crate::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
 use core::ops::{Neg, Not}; // unary ops
 
 macro_rules! neg {
-    ($(impl<const LANES: usize> Neg for Simd<$scalar:ty, LANES>)*) => {
-        $(impl<const LANES: usize> Neg for Simd<$scalar, LANES>
+    ($(impl<const N: usize> Neg for Simd<$scalar:ty, N>)*) => {
+        $(impl<const N: usize> Neg for Simd<$scalar, N>
         where
             $scalar: SimdElement,
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             type Output = Self;
 
@@ -22,27 +22,27 @@ macro_rules! neg {
 }
 
 neg! {
-    impl<const LANES: usize> Neg for Simd<f32, LANES>
+    impl<const N: usize> Neg for Simd<f32, N>
 
-    impl<const LANES: usize> Neg for Simd<f64, LANES>
+    impl<const N: usize> Neg for Simd<f64, N>
 
-    impl<const LANES: usize> Neg for Simd<i8, LANES>
+    impl<const N: usize> Neg for Simd<i8, N>
 
-    impl<const LANES: usize> Neg for Simd<i16, LANES>
+    impl<const N: usize> Neg for Simd<i16, N>
 
-    impl<const LANES: usize> Neg for Simd<i32, LANES>
+    impl<const N: usize> Neg for Simd<i32, N>
 
-    impl<const LANES: usize> Neg for Simd<i64, LANES>
+    impl<const N: usize> Neg for Simd<i64, N>
 
-    impl<const LANES: usize> Neg for Simd<isize, LANES>
+    impl<const N: usize> Neg for Simd<isize, N>
 }
 
 macro_rules! not {
-    ($(impl<const LANES: usize> Not for Simd<$scalar:ty, LANES>)*) => {
-        $(impl<const LANES: usize> Not for Simd<$scalar, LANES>
+    ($(impl<const N: usize> Not for Simd<$scalar:ty, N>)*) => {
+        $(impl<const N: usize> Not for Simd<$scalar, N>
         where
             $scalar: SimdElement,
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             type Output = Self;
 
@@ -56,23 +56,23 @@ macro_rules! not {
 }
 
 not! {
-    impl<const LANES: usize> Not for Simd<i8, LANES>
+    impl<const N: usize> Not for Simd<i8, N>
 
-    impl<const LANES: usize> Not for Simd<i16, LANES>
+    impl<const N: usize> Not for Simd<i16, N>
 
-    impl<const LANES: usize> Not for Simd<i32, LANES>
+    impl<const N: usize> Not for Simd<i32, N>
 
-    impl<const LANES: usize> Not for Simd<i64, LANES>
+    impl<const N: usize> Not for Simd<i64, N>
 
-    impl<const LANES: usize> Not for Simd<isize, LANES>
+    impl<const N: usize> Not for Simd<isize, N>
 
-    impl<const LANES: usize> Not for Simd<u8, LANES>
+    impl<const N: usize> Not for Simd<u8, N>
 
-    impl<const LANES: usize> Not for Simd<u16, LANES>
+    impl<const N: usize> Not for Simd<u16, N>
 
-    impl<const LANES: usize> Not for Simd<u32, LANES>
+    impl<const N: usize> Not for Simd<u32, N>
 
-    impl<const LANES: usize> Not for Simd<u64, LANES>
+    impl<const N: usize> Not for Simd<u64, N>
 
-    impl<const LANES: usize> Not for Simd<usize, LANES>
+    impl<const N: usize> Not for Simd<usize, N>
 }

--- a/crates/core_simd/src/select.rs
+++ b/crates/core_simd/src/select.rs
@@ -6,10 +6,10 @@ where
     T: MaskElement,
     LaneCount<LANES>: SupportedLaneCount,
 {
-    /// Choose lanes from two vectors.
+    /// Choose elements from two vectors.
     ///
-    /// For each lane in the mask, choose the corresponding lane from `true_values` if
-    /// that lane mask is true, and `false_values` if that lane mask is false.
+    /// For each element in the mask, choose the corresponding element from `true_values` if
+    /// that element mask is true, and `false_values` if that element mask is false.
     ///
     /// # Examples
     /// ```
@@ -36,10 +36,10 @@ where
         unsafe { intrinsics::simd_select(self.to_int(), true_values, false_values) }
     }
 
-    /// Choose lanes from two masks.
+    /// Choose elements from two masks.
     ///
-    /// For each lane in the mask, choose the corresponding lane from `true_values` if
-    /// that lane mask is true, and `false_values` if that lane mask is false.
+    /// For each element in the mask, choose the corresponding element from `true_values` if
+    /// that element mask is true, and `false_values` if that element mask is false.
     ///
     /// # Examples
     /// ```

--- a/crates/core_simd/src/select.rs
+++ b/crates/core_simd/src/select.rs
@@ -23,11 +23,7 @@ where
     /// ```
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn select<U>(
-        self,
-        true_values: Simd<U, N>,
-        false_values: Simd<U, N>,
-    ) -> Simd<U, N>
+    pub fn select<U>(self, true_values: Simd<U, N>, false_values: Simd<U, N>) -> Simd<U, N>
     where
         U: SimdElement<Mask = T>,
     {

--- a/crates/core_simd/src/select.rs
+++ b/crates/core_simd/src/select.rs
@@ -1,10 +1,10 @@
 use crate::simd::intrinsics;
 use crate::simd::{LaneCount, Mask, MaskElement, Simd, SimdElement, SupportedLaneCount};
 
-impl<T, const LANES: usize> Mask<T, LANES>
+impl<T, const N: usize> Mask<T, N>
 where
     T: MaskElement,
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     /// Choose elements from two vectors.
     ///
@@ -25,9 +25,9 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn select<U>(
         self,
-        true_values: Simd<U, LANES>,
-        false_values: Simd<U, LANES>,
-    ) -> Simd<U, LANES>
+        true_values: Simd<U, N>,
+        false_values: Simd<U, N>,
+    ) -> Simd<U, N>
     where
         U: SimdElement<Mask = T>,
     {

--- a/crates/core_simd/src/simd/cmp/eq.rs
+++ b/crates/core_simd/src/simd/cmp/eq.rs
@@ -9,11 +9,11 @@ pub trait SimdPartialEq {
     /// The mask type returned by each comparison.
     type Mask;
 
-    /// Test if each lane is equal to the corresponding lane in `other`.
+    /// Test if each element is equal to the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_eq(self, other: Self) -> Self::Mask;
 
-    /// Test if each lane is equal to the corresponding lane in `other`.
+    /// Test if each element is equal to the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_ne(self, other: Self) -> Self::Mask;
 }

--- a/crates/core_simd/src/simd/cmp/eq.rs
+++ b/crates/core_simd/src/simd/cmp/eq.rs
@@ -21,11 +21,11 @@ pub trait SimdPartialEq {
 macro_rules! impl_number {
     { $($number:ty),* } => {
         $(
-        impl<const LANES: usize> SimdPartialEq for Simd<$number, LANES>
+        impl<const N: usize> SimdPartialEq for Simd<$number, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
-            type Mask = Mask<<$number as SimdElement>::Mask, LANES>;
+            type Mask = Mask<<$number as SimdElement>::Mask, N>;
 
             #[inline]
             fn simd_eq(self, other: Self) -> Self::Mask {
@@ -50,9 +50,9 @@ impl_number! { f32, f64, u8, u16, u32, u64, usize, i8, i16, i32, i64, isize }
 macro_rules! impl_mask {
     { $($integer:ty),* } => {
         $(
-        impl<const LANES: usize> SimdPartialEq for Mask<$integer, LANES>
+        impl<const N: usize> SimdPartialEq for Mask<$integer, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             type Mask = Self;
 
@@ -76,11 +76,11 @@ macro_rules! impl_mask {
 
 impl_mask! { i8, i16, i32, i64, isize }
 
-impl<T, const LANES: usize> SimdPartialEq for Simd<*const T, LANES>
+impl<T, const N: usize> SimdPartialEq for Simd<*const T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<isize, N>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {
@@ -93,11 +93,11 @@ where
     }
 }
 
-impl<T, const LANES: usize> SimdPartialEq for Simd<*mut T, LANES>
+impl<T, const N: usize> SimdPartialEq for Simd<*mut T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, LANES>;
+    type Mask = Mask<isize, N>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {

--- a/crates/core_simd/src/simd/cmp/ord.rs
+++ b/crates/core_simd/src/simd/cmp/ord.rs
@@ -49,9 +49,9 @@ pub trait SimdOrd: SimdPartialOrd {
 macro_rules! impl_integer {
     { $($integer:ty),* } => {
         $(
-        impl<const LANES: usize> SimdPartialOrd for Simd<$integer, LANES>
+        impl<const N: usize> SimdPartialOrd for Simd<$integer, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn simd_lt(self, other: Self) -> Self::Mask {
@@ -82,9 +82,9 @@ macro_rules! impl_integer {
             }
         }
 
-        impl<const LANES: usize> SimdOrd for Simd<$integer, LANES>
+        impl<const N: usize> SimdOrd for Simd<$integer, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn simd_max(self, other: Self) -> Self {
@@ -115,9 +115,9 @@ impl_integer! { u8, u16, u32, u64, usize, i8, i16, i32, i64, isize }
 macro_rules! impl_float {
     { $($float:ty),* } => {
         $(
-        impl<const LANES: usize> SimdPartialOrd for Simd<$float, LANES>
+        impl<const N: usize> SimdPartialOrd for Simd<$float, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn simd_lt(self, other: Self) -> Self::Mask {
@@ -156,9 +156,9 @@ impl_float! { f32, f64 }
 macro_rules! impl_mask {
     { $($integer:ty),* } => {
         $(
-        impl<const LANES: usize> SimdPartialOrd for Mask<$integer, LANES>
+        impl<const N: usize> SimdPartialOrd for Mask<$integer, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn simd_lt(self, other: Self) -> Self::Mask {
@@ -189,9 +189,9 @@ macro_rules! impl_mask {
             }
         }
 
-        impl<const LANES: usize> SimdOrd for Mask<$integer, LANES>
+        impl<const N: usize> SimdOrd for Mask<$integer, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             #[inline]
             fn simd_max(self, other: Self) -> Self {
@@ -219,9 +219,9 @@ macro_rules! impl_mask {
 
 impl_mask! { i8, i16, i32, i64, isize }
 
-impl<T, const LANES: usize> SimdPartialOrd for Simd<*const T, LANES>
+impl<T, const N: usize> SimdPartialOrd for Simd<*const T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     #[inline]
     fn simd_lt(self, other: Self) -> Self::Mask {
@@ -244,9 +244,9 @@ where
     }
 }
 
-impl<T, const LANES: usize> SimdOrd for Simd<*const T, LANES>
+impl<T, const N: usize> SimdOrd for Simd<*const T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     #[inline]
     fn simd_max(self, other: Self) -> Self {
@@ -269,9 +269,9 @@ where
     }
 }
 
-impl<T, const LANES: usize> SimdPartialOrd for Simd<*mut T, LANES>
+impl<T, const N: usize> SimdPartialOrd for Simd<*mut T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     #[inline]
     fn simd_lt(self, other: Self) -> Self::Mask {
@@ -294,9 +294,9 @@ where
     }
 }
 
-impl<T, const LANES: usize> SimdOrd for Simd<*mut T, LANES>
+impl<T, const N: usize> SimdOrd for Simd<*mut T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     #[inline]
     fn simd_max(self, other: Self) -> Self {

--- a/crates/core_simd/src/simd/cmp/ord.rs
+++ b/crates/core_simd/src/simd/cmp/ord.rs
@@ -7,41 +7,41 @@ use crate::simd::{
 
 /// Parallel `PartialOrd`.
 pub trait SimdPartialOrd: SimdPartialEq {
-    /// Test if each lane is less than the corresponding lane in `other`.
+    /// Test if each element is less than the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_lt(self, other: Self) -> Self::Mask;
 
-    /// Test if each lane is less than or equal to the corresponding lane in `other`.
+    /// Test if each element is less than or equal to the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_le(self, other: Self) -> Self::Mask;
 
-    /// Test if each lane is greater than the corresponding lane in `other`.
+    /// Test if each element is greater than the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_gt(self, other: Self) -> Self::Mask;
 
-    /// Test if each lane is greater than or equal to the corresponding lane in `other`.
+    /// Test if each element is greater than or equal to the corresponding element in `other`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn simd_ge(self, other: Self) -> Self::Mask;
 }
 
 /// Parallel `Ord`.
 pub trait SimdOrd: SimdPartialOrd {
-    /// Returns the lane-wise maximum with `other`.
+    /// Returns the element-wise maximum with `other`.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_max(self, other: Self) -> Self;
 
-    /// Returns the lane-wise minimum with `other`.
+    /// Returns the element-wise minimum with `other`.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_min(self, other: Self) -> Self;
 
-    /// Restrict each lane to a certain interval.
+    /// Restrict each element to a certain interval.
     ///
-    /// For each lane, returns `max` if `self` is greater than `max`, and `min` if `self` is
+    /// For each element, returns `max` if `self` is greater than `max`, and `min` if `self` is
     /// less than `min`. Otherwise returns `self`.
     ///
     /// # Panics
     ///
-    /// Panics if `min > max` on any lane.
+    /// Panics if `min > max` on any element.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_clamp(self, min: Self, max: Self) -> Self;
 }
@@ -101,7 +101,7 @@ macro_rules! impl_integer {
             fn simd_clamp(self, min: Self, max: Self) -> Self {
                 assert!(
                     min.simd_le(max).all(),
-                    "each lane in `min` must be less than or equal to the corresponding lane in `max`",
+                    "each element in `min` must be less than or equal to the corresponding element in `max`",
                 );
                 self.simd_max(min).simd_min(max)
             }
@@ -208,7 +208,7 @@ macro_rules! impl_mask {
             fn simd_clamp(self, min: Self, max: Self) -> Self {
                 assert!(
                     min.simd_le(max).all(),
-                    "each lane in `min` must be less than or equal to the corresponding lane in `max`",
+                    "each element in `min` must be less than or equal to the corresponding element in `max`",
                 );
                 self.simd_max(min).simd_min(max)
             }
@@ -263,7 +263,7 @@ where
     fn simd_clamp(self, min: Self, max: Self) -> Self {
         assert!(
             min.simd_le(max).all(),
-            "each lane in `min` must be less than or equal to the corresponding lane in `max`",
+            "each element in `min` must be less than or equal to the corresponding element in `max`",
         );
         self.simd_max(min).simd_min(max)
     }
@@ -313,7 +313,7 @@ where
     fn simd_clamp(self, min: Self, max: Self) -> Self {
         assert!(
             min.simd_le(max).all(),
-            "each lane in `min` must be less than or equal to the corresponding lane in `max`",
+            "each element in `min` must be less than or equal to the corresponding element in `max`",
         );
         self.simd_max(min).simd_min(max)
     }

--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -240,20 +240,20 @@ pub trait SimdFloat: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ty { bits: $bits_ty:ty, mask: $mask_ty:ty }),* } => {
         $(
-        impl<const LANES: usize> Sealed for Simd<$ty, LANES>
+        impl<const N: usize> Sealed for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
         }
 
-        impl<const LANES: usize> SimdFloat for Simd<$ty, LANES>
+        impl<const N: usize> SimdFloat for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
-            type Mask = Mask<<$mask_ty as SimdElement>::Mask, LANES>;
+            type Mask = Mask<<$mask_ty as SimdElement>::Mask, N>;
             type Scalar = $ty;
-            type Bits = Simd<$bits_ty, LANES>;
-            type Cast<T: SimdElement> = Simd<T, LANES>;
+            type Bits = Simd<$bits_ty, N>;
+            type Cast<T: SimdElement> = Simd<T, N>;
 
             #[inline]
             fn cast<T: SimdCast>(self) -> Self::Cast<T>
@@ -273,14 +273,14 @@ macro_rules! impl_trait {
             }
 
             #[inline]
-            fn to_bits(self) -> Simd<$bits_ty, LANES> {
+            fn to_bits(self) -> Simd<$bits_ty, N> {
                 assert_eq!(core::mem::size_of::<Self>(), core::mem::size_of::<Self::Bits>());
                 // Safety: transmuting between vector types is safe
                 unsafe { core::mem::transmute_copy(&self) }
             }
 
             #[inline]
-            fn from_bits(bits: Simd<$bits_ty, LANES>) -> Self {
+            fn from_bits(bits: Simd<$bits_ty, N>) -> Self {
                 assert_eq!(core::mem::size_of::<Self>(), core::mem::size_of::<Self::Bits>());
                 // Safety: transmuting between vector types is safe
                 unsafe { core::mem::transmute_copy(&bits) }

--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -63,64 +63,64 @@ pub trait SimdFloat: Copy + Sealed {
         Self::Scalar: core::convert::FloatToInt<I>;
 
     /// Raw transmutation to an unsigned integer vector type with the
-    /// same size and number of lanes.
+    /// same size and number of elements.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn to_bits(self) -> Self::Bits;
 
     /// Raw transmutation from an unsigned integer vector type with the
-    /// same size and number of lanes.
+    /// same size and number of elements.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn from_bits(bits: Self::Bits) -> Self;
 
-    /// Produces a vector where every lane has the absolute value of the
-    /// equivalently-indexed lane in `self`.
+    /// Produces a vector where every element has the absolute value of the
+    /// equivalently-indexed element in `self`.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn abs(self) -> Self;
 
-    /// Takes the reciprocal (inverse) of each lane, `1/x`.
+    /// Takes the reciprocal (inverse) of each element, `1/x`.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn recip(self) -> Self;
 
-    /// Converts each lane from radians to degrees.
+    /// Converts each element from radians to degrees.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn to_degrees(self) -> Self;
 
-    /// Converts each lane from degrees to radians.
+    /// Converts each element from degrees to radians.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn to_radians(self) -> Self;
 
-    /// Returns true for each lane if it has a positive sign, including
+    /// Returns true for each element if it has a positive sign, including
     /// `+0.0`, `NaN`s with positive sign bit and positive infinity.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_sign_positive(self) -> Self::Mask;
 
-    /// Returns true for each lane if it has a negative sign, including
+    /// Returns true for each element if it has a negative sign, including
     /// `-0.0`, `NaN`s with negative sign bit and negative infinity.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_sign_negative(self) -> Self::Mask;
 
-    /// Returns true for each lane if its value is `NaN`.
+    /// Returns true for each element if its value is `NaN`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_nan(self) -> Self::Mask;
 
-    /// Returns true for each lane if its value is positive infinity or negative infinity.
+    /// Returns true for each element if its value is positive infinity or negative infinity.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_infinite(self) -> Self::Mask;
 
-    /// Returns true for each lane if its value is neither infinite nor `NaN`.
+    /// Returns true for each element if its value is neither infinite nor `NaN`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_finite(self) -> Self::Mask;
 
-    /// Returns true for each lane if its value is subnormal.
+    /// Returns true for each element if its value is subnormal.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_subnormal(self) -> Self::Mask;
 
-    /// Returns true for each lane if its value is neither zero, infinite,
+    /// Returns true for each element if its value is neither zero, infinite,
     /// subnormal, nor `NaN`.
     #[must_use = "method returns a new mask and does not mutate the original value"]
     fn is_normal(self) -> Self::Mask;
 
-    /// Replaces each lane with a number that represents its sign.
+    /// Replaces each element with a number that represents its sign.
     ///
     /// * `1.0` if the number is positive, `+0.0`, or `INFINITY`
     /// * `-1.0` if the number is negative, `-0.0`, or `NEG_INFINITY`
@@ -128,33 +128,33 @@ pub trait SimdFloat: Copy + Sealed {
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn signum(self) -> Self;
 
-    /// Returns each lane with the magnitude of `self` and the sign of `sign`.
+    /// Returns each element with the magnitude of `self` and the sign of `sign`.
     ///
-    /// For any lane containing a `NAN`, a `NAN` with the sign of `sign` is returned.
+    /// For any element containing a `NAN`, a `NAN` with the sign of `sign` is returned.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn copysign(self, sign: Self) -> Self;
 
-    /// Returns the minimum of each lane.
+    /// Returns the minimum of each element.
     ///
     /// If one of the values is `NAN`, then the other value is returned.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_min(self, other: Self) -> Self;
 
-    /// Returns the maximum of each lane.
+    /// Returns the maximum of each element.
     ///
     /// If one of the values is `NAN`, then the other value is returned.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_max(self, other: Self) -> Self;
 
-    /// Restrict each lane to a certain interval unless it is NaN.
+    /// Restrict each element to a certain interval unless it is NaN.
     ///
-    /// For each lane in `self`, returns the corresponding lane in `max` if the lane is
-    /// greater than `max`, and the corresponding lane in `min` if the lane is less
-    /// than `min`.  Otherwise returns the lane in `self`.
+    /// For each element in `self`, returns the corresponding element in `max` if the element is
+    /// greater than `max`, and the corresponding element in `min` if the element is less
+    /// than `min`.  Otherwise returns the element in `self`.
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn simd_clamp(self, min: Self, max: Self) -> Self;
 
-    /// Returns the sum of the lanes of the vector.
+    /// Returns the sum of the elements of the vector.
     ///
     /// # Examples
     ///
@@ -168,7 +168,7 @@ pub trait SimdFloat: Copy + Sealed {
     /// ```
     fn reduce_sum(self) -> Self::Scalar;
 
-    /// Reducing multiply.  Returns the product of the lanes of the vector.
+    /// Reducing multiply.  Returns the product of the elements of the vector.
     ///
     /// # Examples
     ///
@@ -182,12 +182,12 @@ pub trait SimdFloat: Copy + Sealed {
     /// ```
     fn reduce_product(self) -> Self::Scalar;
 
-    /// Returns the maximum lane in the vector.
+    /// Returns the maximum element in the vector.
     ///
     /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
     /// return either.
     ///
-    /// This function will not return `NaN` unless all lanes are `NaN`.
+    /// This function will not return `NaN` unless all elements are `NaN`.
     ///
     /// # Examples
     ///
@@ -209,12 +209,12 @@ pub trait SimdFloat: Copy + Sealed {
     /// ```
     fn reduce_max(self) -> Self::Scalar;
 
-    /// Returns the minimum lane in the vector.
+    /// Returns the minimum element in the vector.
     ///
     /// Returns values based on equality, so a vector containing both `0.` and `-0.` may
     /// return either.
     ///
-    /// This function will not return `NaN` unless all lanes are `NaN`.
+    /// This function will not return `NaN` unless all elements are `NaN`.
     ///
     /// # Examples
     ///
@@ -376,7 +376,7 @@ macro_rules! impl_trait {
             fn simd_clamp(self, min: Self, max: Self) -> Self {
                 assert!(
                     min.simd_le(max).all(),
-                    "each lane in `min` must be less than or equal to the corresponding lane in `max`",
+                    "each element in `min` must be less than or equal to the corresponding element in `max`",
                 );
                 let mut x = self;
                 x = x.simd_lt(min).select(min, x);

--- a/crates/core_simd/src/simd/num/int.rs
+++ b/crates/core_simd/src/simd/num/int.rs
@@ -219,20 +219,20 @@ pub trait SimdInt: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ident ($unsigned:ident)),* } => {
         $(
-        impl<const LANES: usize> Sealed for Simd<$ty, LANES>
+        impl<const N: usize> Sealed for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
         }
 
-        impl<const LANES: usize> SimdInt for Simd<$ty, LANES>
+        impl<const N: usize> SimdInt for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
-            type Mask = Mask<<$ty as SimdElement>::Mask, LANES>;
+            type Mask = Mask<<$ty as SimdElement>::Mask, N>;
             type Scalar = $ty;
-            type Unsigned = Simd<$unsigned, LANES>;
-            type Cast<T: SimdElement> = Simd<T, LANES>;
+            type Unsigned = Simd<$unsigned, N>;
+            type Cast<T: SimdElement> = Simd<T, N>;
 
             #[inline]
             fn cast<T: SimdCast>(self) -> Self::Cast<T> {

--- a/crates/core_simd/src/simd/num/int.rs
+++ b/crates/core_simd/src/simd/num/int.rs
@@ -61,7 +61,7 @@ pub trait SimdInt: Copy + Sealed {
     fn saturating_sub(self, second: Self) -> Self;
 
     /// Lanewise absolute value, implemented in Rust.
-    /// Every lane becomes its absolute value.
+    /// Every element becomes its absolute value.
     ///
     /// # Examples
     /// ```
@@ -111,19 +111,19 @@ pub trait SimdInt: Copy + Sealed {
     /// ```
     fn saturating_neg(self) -> Self;
 
-    /// Returns true for each positive lane and false if it is zero or negative.
+    /// Returns true for each positive element and false if it is zero or negative.
     fn is_positive(self) -> Self::Mask;
 
-    /// Returns true for each negative lane and false if it is zero or positive.
+    /// Returns true for each negative element and false if it is zero or positive.
     fn is_negative(self) -> Self::Mask;
 
-    /// Returns numbers representing the sign of each lane.
+    /// Returns numbers representing the sign of each element.
     /// * `0` if the number is zero
     /// * `1` if the number is positive
     /// * `-1` if the number is negative
     fn signum(self) -> Self;
 
-    /// Returns the sum of the lanes of the vector, with wrapping addition.
+    /// Returns the sum of the elements of the vector, with wrapping addition.
     ///
     /// # Examples
     ///
@@ -141,7 +141,7 @@ pub trait SimdInt: Copy + Sealed {
     /// ```
     fn reduce_sum(self) -> Self::Scalar;
 
-    /// Returns the product of the lanes of the vector, with wrapping multiplication.
+    /// Returns the product of the elements of the vector, with wrapping multiplication.
     ///
     /// # Examples
     ///
@@ -159,7 +159,7 @@ pub trait SimdInt: Copy + Sealed {
     /// ```
     fn reduce_product(self) -> Self::Scalar;
 
-    /// Returns the maximum lane in the vector.
+    /// Returns the maximum element in the vector.
     ///
     /// # Examples
     ///
@@ -173,7 +173,7 @@ pub trait SimdInt: Copy + Sealed {
     /// ```
     fn reduce_max(self) -> Self::Scalar;
 
-    /// Returns the minimum lane in the vector.
+    /// Returns the minimum element in the vector.
     ///
     /// # Examples
     ///
@@ -187,13 +187,13 @@ pub trait SimdInt: Copy + Sealed {
     /// ```
     fn reduce_min(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "and" across the lanes of the vector.
+    /// Returns the cumulative bitwise "and" across the elements of the vector.
     fn reduce_and(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "or" across the lanes of the vector.
+    /// Returns the cumulative bitwise "or" across the elements of the vector.
     fn reduce_or(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "xor" across the lanes of the vector.
+    /// Returns the cumulative bitwise "xor" across the elements of the vector.
     fn reduce_xor(self) -> Self::Scalar;
 
     /// Reverses the byte order of each element.

--- a/crates/core_simd/src/simd/num/uint.rs
+++ b/crates/core_simd/src/simd/num/uint.rs
@@ -57,25 +57,25 @@ pub trait SimdUint: Copy + Sealed {
     /// assert_eq!(sat, Simd::splat(0));
     fn saturating_sub(self, second: Self) -> Self;
 
-    /// Returns the sum of the lanes of the vector, with wrapping addition.
+    /// Returns the sum of the elements of the vector, with wrapping addition.
     fn reduce_sum(self) -> Self::Scalar;
 
-    /// Returns the product of the lanes of the vector, with wrapping multiplication.
+    /// Returns the product of the elements of the vector, with wrapping multiplication.
     fn reduce_product(self) -> Self::Scalar;
 
-    /// Returns the maximum lane in the vector.
+    /// Returns the maximum element in the vector.
     fn reduce_max(self) -> Self::Scalar;
 
-    /// Returns the minimum lane in the vector.
+    /// Returns the minimum element in the vector.
     fn reduce_min(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "and" across the lanes of the vector.
+    /// Returns the cumulative bitwise "and" across the elements of the vector.
     fn reduce_and(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "or" across the lanes of the vector.
+    /// Returns the cumulative bitwise "or" across the elements of the vector.
     fn reduce_or(self) -> Self::Scalar;
 
-    /// Returns the cumulative bitwise "xor" across the lanes of the vector.
+    /// Returns the cumulative bitwise "xor" across the elements of the vector.
     fn reduce_xor(self) -> Self::Scalar;
 
     /// Reverses the byte order of each element.

--- a/crates/core_simd/src/simd/num/uint.rs
+++ b/crates/core_simd/src/simd/num/uint.rs
@@ -101,18 +101,18 @@ pub trait SimdUint: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ident ($signed:ident)),* } => {
         $(
-        impl<const LANES: usize> Sealed for Simd<$ty, LANES>
+        impl<const N: usize> Sealed for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
         }
 
-        impl<const LANES: usize> SimdUint for Simd<$ty, LANES>
+        impl<const N: usize> SimdUint for Simd<$ty, N>
         where
-            LaneCount<LANES>: SupportedLaneCount,
+            LaneCount<N>: SupportedLaneCount,
         {
             type Scalar = $ty;
-            type Cast<T: SimdElement> = Simd<T, LANES>;
+            type Cast<T: SimdElement> = Simd<T, N>;
 
             #[inline]
             fn cast<T: SimdCast>(self) -> Self::Cast<T> {

--- a/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -5,13 +5,13 @@ use crate::simd::{
 
 /// Operations on SIMD vectors of constant pointers.
 pub trait SimdConstPtr: Copy + Sealed {
-    /// Vector of `usize` with the same number of lanes.
+    /// Vector of `usize` with the same number of elements.
     type Usize;
 
-    /// Vector of `isize` with the same number of lanes.
+    /// Vector of `isize` with the same number of elements.
     type Isize;
 
-    /// Vector of const pointers with the same number of lanes.
+    /// Vector of const pointers with the same number of elements.
     type CastPtr<T>;
 
     /// Vector of mutable pointers to the same type.
@@ -20,17 +20,17 @@ pub trait SimdConstPtr: Copy + Sealed {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 
-    /// Returns `true` for each lane that is null.
+    /// Returns `true` for each element that is null.
     fn is_null(self) -> Self::Mask;
 
     /// Casts to a pointer of another type.
     ///
-    /// Equivalent to calling [`pointer::cast`] on each lane.
+    /// Equivalent to calling [`pointer::cast`] on each element.
     fn cast<T>(self) -> Self::CastPtr<T>;
 
     /// Changes constness without changing the type.
     ///
-    /// Equivalent to calling [`pointer::cast_mut`] on each lane.
+    /// Equivalent to calling [`pointer::cast_mut`] on each element.
     fn cast_mut(self) -> Self::MutPtr;
 
     /// Gets the "address" portion of the pointer.
@@ -41,7 +41,7 @@ pub trait SimdConstPtr: Copy + Sealed {
     /// This method semantically discards *provenance* and
     /// *address-space* information. To properly restore that information, use [`Self::with_addr`].
     ///
-    /// Equivalent to calling [`pointer::addr`] on each lane.
+    /// Equivalent to calling [`pointer::addr`] on each element.
     fn addr(self) -> Self::Usize;
 
     /// Creates a new pointer with the given address.
@@ -49,7 +49,7 @@ pub trait SimdConstPtr: Copy + Sealed {
     /// This performs the same operation as a cast, but copies the *address-space* and
     /// *provenance* of `self` to the new pointer.
     ///
-    /// Equivalent to calling [`pointer::with_addr`] on each lane.
+    /// Equivalent to calling [`pointer::with_addr`] on each element.
     fn with_addr(self, addr: Self::Usize) -> Self;
 
     /// Gets the "address" portion of the pointer, and "exposes" the provenance part for future use
@@ -58,22 +58,22 @@ pub trait SimdConstPtr: Copy + Sealed {
 
     /// Convert an address back to a pointer, picking up a previously "exposed" provenance.
     ///
-    /// Equivalent to calling [`core::ptr::from_exposed_addr`] on each lane.
+    /// Equivalent to calling [`core::ptr::from_exposed_addr`] on each element.
     fn from_exposed_addr(addr: Self::Usize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_offset`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_offset`] on each element.
     fn wrapping_offset(self, offset: Self::Isize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_add`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_add`] on each element.
     fn wrapping_add(self, count: Self::Usize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_sub`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_sub`] on each element.
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 

--- a/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -77,10 +77,7 @@ pub trait SimdConstPtr: Copy + Sealed {
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 
-impl<T, const N: usize> Sealed for Simd<*const T, N> where
-    LaneCount<N>: SupportedLaneCount
-{
-}
+impl<T, const N: usize> Sealed for Simd<*const T, N> where LaneCount<N>: SupportedLaneCount {}
 
 impl<T, const N: usize> SimdConstPtr for Simd<*const T, N>
 where

--- a/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -77,20 +77,20 @@ pub trait SimdConstPtr: Copy + Sealed {
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 
-impl<T, const LANES: usize> Sealed for Simd<*const T, LANES> where
-    LaneCount<LANES>: SupportedLaneCount
+impl<T, const N: usize> Sealed for Simd<*const T, N> where
+    LaneCount<N>: SupportedLaneCount
 {
 }
 
-impl<T, const LANES: usize> SimdConstPtr for Simd<*const T, LANES>
+impl<T, const N: usize> SimdConstPtr for Simd<*const T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
-    type Usize = Simd<usize, LANES>;
-    type Isize = Simd<isize, LANES>;
-    type CastPtr<U> = Simd<*const U, LANES>;
-    type MutPtr = Simd<*mut T, LANES>;
-    type Mask = Mask<isize, LANES>;
+    type Usize = Simd<usize, N>;
+    type Isize = Simd<isize, N>;
+    type CastPtr<U> = Simd<*const U, N>;
+    type MutPtr = Simd<*mut T, N>;
+    type Mask = Mask<isize, N>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -5,13 +5,13 @@ use crate::simd::{
 
 /// Operations on SIMD vectors of mutable pointers.
 pub trait SimdMutPtr: Copy + Sealed {
-    /// Vector of `usize` with the same number of lanes.
+    /// Vector of `usize` with the same number of elements.
     type Usize;
 
-    /// Vector of `isize` with the same number of lanes.
+    /// Vector of `isize` with the same number of elements.
     type Isize;
 
-    /// Vector of const pointers with the same number of lanes.
+    /// Vector of const pointers with the same number of elements.
     type CastPtr<T>;
 
     /// Vector of constant pointers to the same type.
@@ -20,17 +20,17 @@ pub trait SimdMutPtr: Copy + Sealed {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 
-    /// Returns `true` for each lane that is null.
+    /// Returns `true` for each element that is null.
     fn is_null(self) -> Self::Mask;
 
     /// Casts to a pointer of another type.
     ///
-    /// Equivalent to calling [`pointer::cast`] on each lane.
+    /// Equivalent to calling [`pointer::cast`] on each element.
     fn cast<T>(self) -> Self::CastPtr<T>;
 
     /// Changes constness without changing the type.
     ///
-    /// Equivalent to calling [`pointer::cast_const`] on each lane.
+    /// Equivalent to calling [`pointer::cast_const`] on each element.
     fn cast_const(self) -> Self::ConstPtr;
 
     /// Gets the "address" portion of the pointer.
@@ -38,7 +38,7 @@ pub trait SimdMutPtr: Copy + Sealed {
     /// This method discards pointer semantic metadata, so the result cannot be
     /// directly cast into a valid pointer.
     ///
-    /// Equivalent to calling [`pointer::addr`] on each lane.
+    /// Equivalent to calling [`pointer::addr`] on each element.
     fn addr(self) -> Self::Usize;
 
     /// Creates a new pointer with the given address.
@@ -46,7 +46,7 @@ pub trait SimdMutPtr: Copy + Sealed {
     /// This performs the same operation as a cast, but copies the *address-space* and
     /// *provenance* of `self` to the new pointer.
     ///
-    /// Equivalent to calling [`pointer::with_addr`] on each lane.
+    /// Equivalent to calling [`pointer::with_addr`] on each element.
     fn with_addr(self, addr: Self::Usize) -> Self;
 
     /// Gets the "address" portion of the pointer, and "exposes" the provenance part for future use
@@ -55,22 +55,22 @@ pub trait SimdMutPtr: Copy + Sealed {
 
     /// Convert an address back to a pointer, picking up a previously "exposed" provenance.
     ///
-    /// Equivalent to calling [`core::ptr::from_exposed_addr_mut`] on each lane.
+    /// Equivalent to calling [`core::ptr::from_exposed_addr_mut`] on each element.
     fn from_exposed_addr(addr: Self::Usize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_offset`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_offset`] on each element.
     fn wrapping_offset(self, offset: Self::Isize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_add`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_add`] on each element.
     fn wrapping_add(self, count: Self::Usize) -> Self;
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
-    /// Equivalent to calling [`pointer::wrapping_sub`] on each lane.
+    /// Equivalent to calling [`pointer::wrapping_sub`] on each element.
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 

--- a/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -74,18 +74,18 @@ pub trait SimdMutPtr: Copy + Sealed {
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 
-impl<T, const LANES: usize> Sealed for Simd<*mut T, LANES> where LaneCount<LANES>: SupportedLaneCount
+impl<T, const N: usize> Sealed for Simd<*mut T, N> where LaneCount<N>: SupportedLaneCount
 {}
 
-impl<T, const LANES: usize> SimdMutPtr for Simd<*mut T, LANES>
+impl<T, const N: usize> SimdMutPtr for Simd<*mut T, N>
 where
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
-    type Usize = Simd<usize, LANES>;
-    type Isize = Simd<isize, LANES>;
-    type CastPtr<U> = Simd<*mut U, LANES>;
-    type ConstPtr = Simd<*const T, LANES>;
-    type Mask = Mask<isize, LANES>;
+    type Usize = Simd<usize, N>;
+    type Isize = Simd<isize, N>;
+    type CastPtr<U> = Simd<*mut U, N>;
+    type ConstPtr = Simd<*const T, N>;
+    type Mask = Mask<isize, N>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -74,8 +74,7 @@ pub trait SimdMutPtr: Copy + Sealed {
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
 
-impl<T, const N: usize> Sealed for Simd<*mut T, N> where LaneCount<N>: SupportedLaneCount
-{}
+impl<T, const N: usize> Sealed for Simd<*mut T, N> where LaneCount<N>: SupportedLaneCount {}
 
 impl<T, const N: usize> SimdMutPtr for Simd<*mut T, N>
 where

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -206,11 +206,11 @@ where
     }
 
     /// Rotates the vector such that the first `OFFSET` elements of the slice move to the end
-    /// while the last `LANES - OFFSET` elements move to the front. After calling `rotate_lanes_left`,
-    /// the element previously in lane `OFFSET` will become the first element in the slice.
+    /// while the last `self.len() - OFFSET` elements move to the front. After calling `rotate_elements_left`,
+    /// the element previously at index `OFFSET` will become the first element in the slice.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn rotate_lanes_left<const OFFSET: usize>(self) -> Self {
+    pub fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
         struct Rotate<const OFFSET: usize>;
 
         impl<const OFFSET: usize, const N: usize> Swizzle<N> for Rotate<OFFSET> {
@@ -229,12 +229,12 @@ where
         Rotate::<OFFSET>::swizzle(self)
     }
 
-    /// Rotates the vector such that the first `LANES - OFFSET` elements of the vector move to
-    /// the end while the last `OFFSET` elements move to the front. After calling `rotate_lanes_right`,
-    /// the element previously at index `LANES - OFFSET` will become the first element in the slice.
+    /// Rotates the vector such that the first `self.len() - OFFSET` elements of the vector move to
+    /// the end while the last `OFFSET` elements move to the front. After calling `rotate_elements_right`,
+    /// the element previously at index `self.len() - OFFSET` will become the first element in the slice.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn rotate_lanes_right<const OFFSET: usize>(self) -> Self {
+    pub fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
         struct Rotate<const OFFSET: usize>;
 
         impl<const OFFSET: usize, const N: usize> Swizzle<N> for Rotate<OFFSET> {

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -179,10 +179,10 @@ pub trait Swizzle<const N: usize> {
     }
 }
 
-impl<T, const LANES: usize> Simd<T, LANES>
+impl<T, const N: usize> Simd<T, N>
 where
     T: SimdElement,
-    LaneCount<LANES>: SupportedLaneCount,
+    LaneCount<N>: SupportedLaneCount,
 {
     /// Reverse the order of the elements in the vector.
     #[inline]

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -112,7 +112,7 @@ where
     T: SimdElement,
 {
     /// Number of elements in this vector.
-    pub const LANES: usize = N;
+    pub const LEN: usize = N;
 
     /// Returns the number of elements in this SIMD vector.
     ///
@@ -122,11 +122,11 @@ where
     /// # #![feature(portable_simd)]
     /// # use core::simd::u32x4;
     /// let v = u32x4::splat(0);
-    /// assert_eq!(v.lanes(), 4);
+    /// assert_eq!(v.len(), 4);
     /// ```
     #[inline]
-    pub const fn lanes(&self) -> usize {
-        Self::LANES
+    pub const fn len(&self) -> usize {
+        Self::LEN
     }
 
     /// Constructs a new SIMD vector with all elements set to the given value.
@@ -273,7 +273,7 @@ where
     #[track_caller]
     pub const fn from_slice(slice: &[T]) -> Self {
         assert!(
-            slice.len() >= Self::LANES,
+            slice.len() >= Self::LEN,
             "slice length must be at least the number of elements"
         );
         // SAFETY: We just checked that the slice contains
@@ -303,7 +303,7 @@ where
     #[track_caller]
     pub fn copy_to_slice(self, slice: &mut [T]) {
         assert!(
-            slice.len() >= Self::LANES,
+            slice.len() >= Self::LEN,
             "slice length must be at least the number of elements"
         );
         // SAFETY: We just checked that the slice contains

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -120,7 +120,9 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::u32x4;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd;
+    /// # use simd::u32x4;
     /// let v = u32x4::splat(0);
     /// assert_eq!(v.len(), 4);
     /// ```
@@ -135,7 +137,9 @@ where
     ///
     /// ```
     /// # #![feature(portable_simd)]
-    /// # use core::simd::u32x4;
+    /// # #[cfg(feature = "as_crate")] use core_simd::simd;
+    /// # #[cfg(not(feature = "as_crate"))] use core::simd;
+    /// # use simd::u32x4;
     /// let v = u32x4::splat(8);
     /// assert_eq!(v.as_array(), &[8, 8, 8, 8]);
     /// ```

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -34,18 +34,18 @@ fn reverse() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn rotate() {
     let a = Simd::from_array([1, 2, 3, 4]);
-    assert_eq!(a.rotate_lanes_left::<0>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.rotate_lanes_left::<1>().to_array(), [2, 3, 4, 1]);
-    assert_eq!(a.rotate_lanes_left::<2>().to_array(), [3, 4, 1, 2]);
-    assert_eq!(a.rotate_lanes_left::<3>().to_array(), [4, 1, 2, 3]);
-    assert_eq!(a.rotate_lanes_left::<4>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.rotate_lanes_left::<5>().to_array(), [2, 3, 4, 1]);
-    assert_eq!(a.rotate_lanes_right::<0>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.rotate_lanes_right::<1>().to_array(), [4, 1, 2, 3]);
-    assert_eq!(a.rotate_lanes_right::<2>().to_array(), [3, 4, 1, 2]);
-    assert_eq!(a.rotate_lanes_right::<3>().to_array(), [2, 3, 4, 1]);
-    assert_eq!(a.rotate_lanes_right::<4>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.rotate_lanes_right::<5>().to_array(), [4, 1, 2, 3]);
+    assert_eq!(a.rotate_elements_left::<0>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.rotate_elements_left::<1>().to_array(), [2, 3, 4, 1]);
+    assert_eq!(a.rotate_elements_left::<2>().to_array(), [3, 4, 1, 2]);
+    assert_eq!(a.rotate_elements_left::<3>().to_array(), [4, 1, 2, 3]);
+    assert_eq!(a.rotate_elements_left::<4>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.rotate_elements_left::<5>().to_array(), [2, 3, 4, 1]);
+    assert_eq!(a.rotate_elements_right::<0>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.rotate_elements_right::<1>().to_array(), [4, 1, 2, 3]);
+    assert_eq!(a.rotate_elements_right::<2>().to_array(), [3, 4, 1, 2]);
+    assert_eq!(a.rotate_elements_right::<3>().to_array(), [2, 3, 4, 1]);
+    assert_eq!(a.rotate_elements_right::<4>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.rotate_elements_right::<5>().to_array(), [4, 1, 2, 3]);
 }
 
 #[test]


### PR DESCRIPTION
In an attempt to use uniform language, I've changed most instances of "lane" to "element"

This is a huge PR, but to sum it up, there are some interface changes:
* Rename `Simd::LANES` to `Simd::LEN`
* Rename `Simd::lanes()` to `Simd::len()`
* Rename `Simd::rotate_lanes_{left,right}` to `Simd::rotate_elements_{left,right}`

Additionally, I updated documentation, and changed all generic parameters `LANES` to `N`.

I didn't touch `LaneCount` and `SupportedLaneCount`, but I figure those should be changed to be consistent.  `SimdLen` and `SupportedSimdLen`?