### PR TITLE
Add support for masked loads & stores

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -107,6 +107,15 @@ extern "platform-intrinsic" {
     /// like gather, but more spicy, as it writes instead of reads
     pub(crate) fn simd_scatter<T, U, V>(val: T, ptr: U, mask: V);
 
+    /// like a loop of reads offset from the same pointer
+    /// val: vector of values to select if a lane is masked
+    /// ptr: vector of pointers to read from
+    /// mask: a "wide" mask of integers, selects as if simd_select(mask, read(ptr), val)
+    /// note, the LLVM intrinsic accepts a mask vector of `<N x i1>`
+    pub(crate) fn simd_masked_load<T, U, V>(val: T, ptr: U, mask: V) -> T;
+    /// like masked_load, but more spicy, as it writes instead of reads
+    pub(crate) fn simd_masked_store<T, U, V>(val: T, ptr: U, mask: V);
+
     // {s,u}add.sat
     pub(crate) fn simd_saturating_add<T>(x: T, y: T) -> T;
 


### PR DESCRIPTION
Resolves the masked loads/stores checklist item from https://github.com/rust-lang/portable-simd/issues/16

Depends on rustc exposing new intrinsics - https://github.com/rust-lang/rust/pull/117953