### PR TITLE
fix simd_bitmask docs

### DIFF
--- a/crates/core_simd/src/intrinsics.rs
+++ b/crates/core_simd/src/intrinsics.rs
@@ -132,9 +132,10 @@ extern "platform-intrinsic" {
     // `fn simd_bitmask(vector) -> unsigned integer` takes a vector of integers and
     // returns either an unsigned integer or array of `u8`.
     // Every element in the vector becomes a single bit in the returned bitmask.
-    // If the vector has less than 8 lanes, a u8 is returned with zeroed trailing bits.
     // The bit order of the result depends on the byte endianness. LSB-first for little
     // endian and MSB-first for big endian.
+    // If the vector has less than 8 lanes, the mask lives in the least-significant bits
+    // (e.g., [true, false] becomes `0b01` on little endian and `0b10` on big endian).
     //
     // UB if called on a vector with values other than 0 and -1.
     #[allow(unused)]


### PR DESCRIPTION
Seems like we forgot to update the docs when https://github.com/rust-lang/portable-simd/pull/267 landed. This documentation matches the follow testcase:
```rust
    let values = [false, false, false, true];
    let mask = Mask::<i64, 4>::from_array(values);

    unsafe {
        let bitmask1: u8 = simd_bitmask(mask.to_int());
        let bitmask2: [u8; 1] = simd_bitmask(mask.to_int());
        if cfg!(target_endian = "little") {
            assert_eq!(bitmask1, 0b1000);
            assert_eq!(bitmask2, [0b1000]);
        } else {
            assert_eq!(bitmask1, 0b0001);
            assert_eq!(bitmask2, [0b0001]);
        }
    }
```