### PR TITLE
Assume masks are correct

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -4,6 +4,7 @@
     const_maybe_uninit_as_mut_ptr,
     const_mut_refs,
     convert_float_to_int,
+    core_intrinsics,
     decl_macro,
     inline_const,
     intra_doc_pointers,

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -175,7 +175,10 @@ where
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub unsafe fn from_int_unchecked(value: Simd<T, N>) -> Self {
         // Safety: the caller must confirm this invariant
-        unsafe { Self(mask_impl::Mask::from_int_unchecked(value)) }
+        unsafe {
+            core::intrinsics::assume(<T as Sealed>::valid(value));
+            Self(mask_impl::Mask::from_int_unchecked(value))
+        }
     }
 
     /// Converts a vector of integers to a mask, where 0 represents `false` and -1


### PR DESCRIPTION
This allows miri to detect when they are not, and may be exploited by LLVM during optimization. Closes https://github.com/rust-lang/portable-simd/issues/384.

Are there any other places we want to inject such assumptions? I avoided it on the `test_unchecked` and such because I think it is likely unnecessary on those cases and may result in aggressive over-optimization, but anywhere it's likely to be called once instead of once-per-element seems like a fine place to put an `assume`.