### PR TITLE
Fix build error on big endian aarch64

### DIFF
--- a/crates/core_simd/src/vendor/arm.rs
+++ b/crates/core_simd/src/vendor/arm.rs
@@ -69,7 +69,7 @@ mod simd32 {
     from_transmute! { unsafe Simd<i8, 4> => int8x4_t }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 mod aarch64 {
     use super::neon::*;
     use super::*;


### PR DESCRIPTION
Since nightly-2024-02-06 which includes https://github.com/rust-lang/stdarch/pull/1485, the build of core_simd on big endian aarch64 is broken.

```console
$ cargo build --target aarch64_be-unknown-linux-gnu -Z build-std
error[E0432]: unresolved import `super::neon`
  --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../portable-simd/crates/core_simd/src/vendor/arm.rs:74:16
   |
74 |     use super::neon::*;
   |                ^^^^ could not find `neon` in `super`

error[E0412]: cannot find type `float64x1_t` in this scope
  --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../portable-simd/crates/core_simd/src/vendor/arm.rs:77:46
   |
77 |     from_transmute! { unsafe Simd<f64, 1> => float64x1_t }
   |                                              ^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `float64x2_t` in this scope
  --> /Users/taiki/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/../../portable-simd/crates/core_simd/src/vendor/arm.rs:78:39
   |
78 |     from_transmute! { unsafe f64x2 => float64x2_t }
   |                                       ^^^^^^^^^^^ not found in this scope
```

(The changes made in https://github.com/rust-lang/rust/pull/117372/files#diff-1d0639f80e64822373516a52eb408dc844e246110aaf75fe421e07388b9dee18 were sufficient for arm but not for aarch64.)

FYI @Amanieu
