### PR TITLE
Remove redundant imports

### DIFF
--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -3,7 +3,6 @@ use crate::simd::{
     ptr::{SimdConstPtr, SimdMutPtr},
     LaneCount, Mask, MaskElement, SupportedLaneCount, Swizzle,
 };
-use core::convert::{TryFrom, TryInto};
 
 /// A SIMD vector with the shape of `[T; N]` but the operations of `T`.
 ///

--- a/crates/core_simd/tests/swizzle_dyn.rs
+++ b/crates/core_simd/tests/swizzle_dyn.rs
@@ -1,6 +1,6 @@
 #![feature(portable_simd)]
 use core::{fmt, ops::RangeInclusive};
-use test_helpers::{self, biteq, make_runner, prop_assert_biteq};
+use test_helpers::{biteq, make_runner, prop_assert_biteq};
 
 fn swizzle_dyn_scalar_ver<const N: usize>(values: [u8; N], idxs: [u8; N]) -> [u8; N] {
     let mut array = [0; N];


### PR DESCRIPTION
This fixes CI failure on the latest nightly: https://github.com/rust-lang/portable-simd/actions/runs/8001283064/job/21852194555?pr=396

```
error: the item `TryFrom` is imported redundantly
 --> crates/core_simd/src/vector.rs:6:21
  |
6 | use core::convert::{TryFrom, TryInto};
  |                     ^^^^^^^
 --> /rustc/3406ada96f8e16e49e947a91db3eba0db45245fa/library/core/src/prelude/mod.rs:46:[30](https://github.com/rust-lang/portable-simd/actions/runs/8001283064/job/21852194555?pr=396#step:5:31)
  |
  = note: the item `TryFrom` is already defined here
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: the item `TryInto` is imported redundantly
 --> crates/core_simd/src/vector.rs:6:30
  |
6 | use core::convert::{TryFrom, TryInto};
  |                              ^^^^^^^
 --> /rustc/[34](https://github.com/rust-lang/portable-simd/actions/runs/8001283064/job/21852194555?pr=396#step:5:35)06ada96f8e16e49e947a91db3eba0db45245fa/library/core/src/prelude/mod.rs:46:39
  |
  = note: the item `TryInto` is already defined here
```