### PR TITLE
fix build error on AVX-512

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -33,6 +33,10 @@
     any(target_arch = "powerpc", target_arch = "powerpc64"),
     feature(stdarch_powerpc)
 )]
+#![cfg_attr(
+    all(target_arch = "x86_64", target_feature = "avx512f"),
+    feature(stdarch_x86_avx512)
+)]
 #![warn(missing_docs, clippy::missing_inline_in_public_items)] // basically all items, really
 #![deny(unsafe_op_in_unsafe_fn, clippy::undocumented_unsafe_blocks)]
 #![allow(internal_features)]


### PR DESCRIPTION
fixes the following compile error (on latest nightly):

```
error[E0658]: use of unstable library feature 'stdarch_x86_avx512'
  --> crates\core_simd\src\swizzle_dyn.rs:59:32
   |
59 |                 32 => transize(x86::_mm256_permutexvar_epi8, zeroing_idxs(idxs), self),
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #111137 <https://github.com/rust-lang/rust/issues/111137> for more information
   = help: add `#![feature(stdarch_x86_avx512)]` to the crate attributes to enable
   = note: this compiler was built on 2024-02-22; consider upgrading it if it is out of date
```