### PR TITLE
Use v1 prelude to match core

### DIFF
--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -13,6 +13,7 @@
     simd_ffi,
     staged_api,
     strict_provenance,
+    prelude_import,
     ptr_metadata
 )]
 #![cfg_attr(
@@ -42,6 +43,10 @@
 #![allow(internal_features)]
 #![unstable(feature = "portable_simd", issue = "86656")]
 //! Portable SIMD module.
+
+#[prelude_import]
+#[allow(unused_imports)]
+use core::prelude::v1::*;
 
 #[path = "mod.rs"]
 mod core_simd;

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -4,6 +4,7 @@ use crate::simd::{
     ptr::{SimdConstPtr, SimdMutPtr},
     LaneCount, Mask, MaskElement, SupportedLaneCount, Swizzle,
 };
+use core::convert::{TryFrom, TryInto};
 
 /// A SIMD vector with the shape of `[T; N]` but the operations of `T`.
 ///


### PR DESCRIPTION
A workaround for rust-lang/rust#122912 for discovered in rust-lang/rust#122905.