### PR TITLE
Deny warnings for doctest, and validate generating docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,11 @@ jobs:
       - name: Test (release)
         run: cargo test --verbose --target=${{ matrix.target }} --release
 
+      - name: Generate docs
+        run: cargo doc --verbose --target=${{ matrix.target }}
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
   wasm-tests:
     name: "wasm (firefox, ${{ matrix.name }})"
     runs-on: ubuntu-latest

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -39,6 +39,7 @@
 )]
 #![warn(missing_docs, clippy::missing_inline_in_public_items)] // basically all items, really
 #![deny(unsafe_op_in_unsafe_fn, clippy::undocumented_unsafe_blocks)]
+#![doc(test(attr(deny(warnings))))]
 #![allow(internal_features)]
 #![unstable(feature = "portable_simd", issue = "86656")]
 //! Portable SIMD module.

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -324,7 +324,7 @@ where
     /// # #![feature(portable_simd)]
     /// # #[cfg(feature = "as_crate")] use core_simd::simd;
     /// # #[cfg(not(feature = "as_crate"))] use core::simd;
-    /// # use simd::{Simd, Mask};
+    /// # use simd::Simd;
     /// let vec: Vec<i32> = vec![10, 11];
     ///
     /// let result = Simd::<i32, 4>::load_or_default(&vec);
@@ -347,7 +347,7 @@ where
     /// # #![feature(portable_simd)]
     /// # #[cfg(feature = "as_crate")] use core_simd::simd;
     /// # #[cfg(not(feature = "as_crate"))] use core::simd;
-    /// # use simd::{Simd, Mask};
+    /// # use simd::Simd;
     /// let vec: Vec<i32> = vec![10, 11];
     /// let or = Simd::from_array([-5, -4, -3, -2]);
     ///
@@ -694,7 +694,7 @@ where
     ///
     /// # Safety
     ///
-    /// Memory addresses for element are calculated [`core::ptr::wrapping_offset`] and
+    /// Memory addresses for element are calculated [`pointer::wrapping_offset`] and
     /// each enabled element must satisfy the same conditions as [`core::ptr::write`].
     #[inline]
     pub unsafe fn store_select_ptr(self, ptr: *mut T, enable: Mask<<T as SimdElement>::Mask, N>) {


### PR DESCRIPTION
During the most recent attempt to update `portable-simd` in rust-lang/rust, we ran into issues with bad links in docs and doc tests failing due to warnings: https://github.com/rust-lang/rust/pull/122905

This change adds checks for both of these in CI:
* Generate docs with warnings disabled.
* Instruct doctest to add `#![deny(warnings)]` to all tests.