### PR TITLE
run Miri tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,3 +273,15 @@ jobs:
         run: |
           echo "Found AVX features: $CPU_FEATURE"
           RUSTFLAGS="-Dwarnings -Ctarget-feature=$CPU_FEATURE" cargo test --all-targets --no-default-features ${{ matrix.features }}
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust
+        run: |
+          rustup update nightly --no-self-update
+          rustup default nightly
+          rustup component add miri rust-src
+      - name: Test (Miri)
+        run: cargo miri test


### PR DESCRIPTION
This is basically the portable-simd version of https://github.com/rust-lang/rust/pull/123506. Miri supports all the intrinsics now (as far as I know)   and this would let us catch regressions before they enter the tree, rather having to chase them when https://github.com/rust-lang/miri-test-libstd/ fails.

If you add/change an intrinsic in the future, there are several options -- do the Miri support together with the codegen support (which anyway has to land before anything can land here), or temporarily disable some tests under Miri, or temporarily disable Miri entirely. I'll leave that to you. I hope this will be fairly rare. :)

Just enabling Miri will likely be too slow, this takes ~45 minutes. I think I'll move the 4-lane tests to `cfg(not(miri))`, there's not really any point in testing many different lane counts as Miri implements those as just a loop anyway.