### PR TITLE
Add Arm64EC to the list of architectures to check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - i686-unknown-linux-gnu
           - i586-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - arm64ec-pc-windows-msvc
           - armv7-unknown-linux-gnueabihf
           # non-nightly since https://github.com/rust-lang/rust/pull/113274
           # - mips-unknown-linux-gnu

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-29"
+channel = "nightly-2024-06-13"
 components = ["rustfmt", "clippy", "miri", "rust-src"]


### PR DESCRIPTION
The `arm64ec-pc-windows-msvc` target has been [promoted to tier 2](https://github.com/rust-lang/rust/pull/126039), so now that there is a prebuilt standard library available for it add it to the list of architectures to check during CI.