### PR TITLE
shift_elements_{left,right}

### DIFF
--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -255,7 +255,7 @@ where
     /// default value (e.g., zero) to the right.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    fn shift_elements_left<const OFFSET: usize>(self) -> Self
+    pub fn shift_elements_left<const OFFSET: usize>(self) -> Self
     where
         T: Default,
     {
@@ -280,7 +280,7 @@ where
     /// default value (e.g., zero) from the left.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    fn shift_elements_right<const OFFSET: usize>(self) -> Self
+    pub fn shift_elements_right<const OFFSET: usize>(self) -> Self
     where
         T: Default,
     {

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -499,18 +499,30 @@ where
     /// `padding` from the right.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original inputs"]
-    pub fn shift_elements_left<const OFFSET: usize>(self, padding: T) -> Self {
+    pub fn shift_elements_left<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>(padding)) }
+        unsafe {
+            Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>(if padding {
+                T::TRUE
+            } else {
+                T::FALSE
+            }))
+        }
     }
 
     /// Shifts the mask elements to the right by `OFFSET`, filling in with
     /// `padding` from the left.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original inputs"]
-    pub fn shift_elements_right<const OFFSET: usize>(self, padding: T) -> Self {
+    pub fn shift_elements_right<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>(padding)) }
+        unsafe {
+            Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>(if padding {
+                T::TRUE
+            } else {
+                T::FALSE
+            }))
+        }
     }
 
     /// Interleave two masks.

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -251,6 +251,56 @@ where
         Rotate::<OFFSET>::swizzle(self)
     }
 
+    /// Shifts the vector elements to the left by `OFFSET`, padding by the
+    /// default value (e.g., zero) to the right.
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    fn shift_elements_left<const OFFSET: usize>(self) -> Self
+    where
+        T: Default,
+    {
+        struct Shift<const OFFSET: usize>;
+
+        impl<const OFFSET: usize, const N: usize> Swizzle<N> for Shift<OFFSET> {
+            const INDEX: [usize; N] = const {
+                let mut index = [N; N];
+                let mut i = 0;
+                while i + OFFSET < N {
+                    index[i] = i + OFFSET;
+                    i += 1;
+                }
+                index
+            };
+        }
+
+        Shift::<OFFSET>::concat_swizzle(self, Self::default())
+    }
+
+    /// Shifts the vector elements to the right by `OFFSET`, padding by the
+    /// default value (e.g., zero) from the left.
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    fn shift_elements_right<const OFFSET: usize>(self) -> Self
+    where
+        T: Default,
+    {
+        struct Shift<const OFFSET: usize>;
+
+        impl<const OFFSET: usize, const N: usize> Swizzle<N> for Shift<OFFSET> {
+            const INDEX: [usize; N] = const {
+                let mut index = [N; N];
+                let mut i = OFFSET;
+                while i < N {
+                    index[i] = i - OFFSET;
+                    i += 1;
+                }
+                index
+            };
+        }
+
+        Shift::<OFFSET>::concat_swizzle(self, Self::default())
+    }
+
     /// Interleave two vectors.
     ///
     /// The resulting vectors contain elements taken alternatively from `self` and `other`, first
@@ -449,6 +499,30 @@ where
     pub fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
         // Safety: swizzles are safe for masks
         unsafe { Self::from_int_unchecked(self.to_int().rotate_elements_right::<OFFSET>()) }
+    }
+
+    /// Shifts the mask elements to the left by `OFFSET`, padding by the
+    /// default value (e.g., zero) to the right.
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    pub fn shift_elements_left<const OFFSET: usize>(self) -> Self
+    where
+        T: Default,
+    {
+        // Safety: swizzles are safe for masks
+        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>()) }
+    }
+
+    /// Shifts the mask elements to the right by `OFFSET`, padding by the
+    /// default value (e.g., `false`) from the left.
+    #[inline]
+    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    pub fn shift_elements_right<const OFFSET: usize>(self) -> Self
+    where
+        T: Default,
+    {
+        // Safety: swizzles are safe for masks
+        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>()) }
     }
 
     /// Interleave two masks.

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -251,14 +251,11 @@ where
         Rotate::<OFFSET>::swizzle(self)
     }
 
-    /// Shifts the vector elements to the left by `OFFSET`, padding by the
-    /// default value (e.g., zero) to the right.
+    /// Shifts the vector elements to the left by `OFFSET`, filling in with
+    /// `padding` from the right.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn shift_elements_left<const OFFSET: usize>(self) -> Self
-    where
-        T: Default,
-    {
+    pub fn shift_elements_left<const OFFSET: usize>(self, padding: T) -> Self {
         struct Shift<const OFFSET: usize>;
 
         impl<const OFFSET: usize, const N: usize> Swizzle<N> for Shift<OFFSET> {
@@ -273,17 +270,14 @@ where
             };
         }
 
-        Shift::<OFFSET>::concat_swizzle(self, Self::default())
+        Shift::<OFFSET>::concat_swizzle(self, Simd::splat(padding))
     }
 
-    /// Shifts the vector elements to the right by `OFFSET`, padding by the
-    /// default value (e.g., zero) from the left.
+    /// Shifts the vector elements to the right by `OFFSET`, filling in with
+    /// `padding` from the left.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn shift_elements_right<const OFFSET: usize>(self) -> Self
-    where
-        T: Default,
-    {
+    pub fn shift_elements_right<const OFFSET: usize>(self, padding: T) -> Self {
         struct Shift<const OFFSET: usize>;
 
         impl<const OFFSET: usize, const N: usize> Swizzle<N> for Shift<OFFSET> {
@@ -298,7 +292,7 @@ where
             };
         }
 
-        Shift::<OFFSET>::concat_swizzle(self, Self::default())
+        Shift::<OFFSET>::concat_swizzle(self, Simd::splat(padding))
     }
 
     /// Interleave two vectors.
@@ -501,28 +495,22 @@ where
         unsafe { Self::from_int_unchecked(self.to_int().rotate_elements_right::<OFFSET>()) }
     }
 
-    /// Shifts the mask elements to the left by `OFFSET`, padding by the
-    /// default value (e.g., zero) to the right.
+    /// Shifts the mask elements to the left by `OFFSET`, filling in with
+    /// `padding` from the right.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn shift_elements_left<const OFFSET: usize>(self) -> Self
-    where
-        T: Default,
-    {
+    pub fn shift_elements_left<const OFFSET: usize>(self, padding: T) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>()) }
+        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>(padding)) }
     }
 
-    /// Shifts the mask elements to the right by `OFFSET`, padding by the
-    /// default value (e.g., `false`) from the left.
+    /// Shifts the mask elements to the right by `OFFSET`, filling in with
+    /// `padding` from the left.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
-    pub fn shift_elements_right<const OFFSET: usize>(self) -> Self
-    where
-        T: Default,
-    {
+    pub fn shift_elements_right<const OFFSET: usize>(self, padding: T) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>()) }
+        unsafe { Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>(padding)) }
     }
 
     /// Interleave two masks.

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -507,7 +507,7 @@ where
     /// Shifts the mask elements to the right by `OFFSET`, filling in with
     /// `padding` from the left.
     #[inline]
-    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    #[must_use = "method returns a new mask and does not mutate the original inputs"]
     pub fn shift_elements_right<const OFFSET: usize>(self, padding: T) -> Self {
         // Safety: swizzles are safe for masks
         unsafe { Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>(padding)) }

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -498,7 +498,7 @@ where
     /// Shifts the mask elements to the left by `OFFSET`, filling in with
     /// `padding` from the right.
     #[inline]
-    #[must_use = "method returns a new vector and does not mutate the original inputs"]
+    #[must_use = "method returns a new mask and does not mutate the original inputs"]
     pub fn shift_elements_left<const OFFSET: usize>(self, padding: T) -> Self {
         // Safety: swizzles are safe for masks
         unsafe { Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>(padding)) }

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -50,6 +50,24 @@ fn rotate() {
 
 #[test]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn shift() {
+    let a = Simd::from_array([1, 2, 3, 4]);
+    assert_eq!(a.shift_elements_left::<0>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.shift_elements_left::<1>().to_array(), [2, 3, 4, 0]);
+    assert_eq!(a.shift_elements_left::<2>().to_array(), [3, 4, 0, 0]);
+    assert_eq!(a.shift_elements_left::<3>().to_array(), [4, 0, 0, 0]);
+    assert_eq!(a.shift_elements_left::<4>().to_array(), [0, 0, 0, 0]);
+    assert_eq!(a.shift_elements_left::<5>().to_array(), [0, 0, 0, 0]);
+    assert_eq!(a.shift_elements_right::<0>().to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.shift_elements_right::<1>().to_array(), [0, 1, 2, 3]);
+    assert_eq!(a.shift_elements_right::<2>().to_array(), [0, 0, 1, 2]);
+    assert_eq!(a.shift_elements_right::<3>().to_array(), [0, 0, 0, 1]);
+    assert_eq!(a.shift_elements_right::<4>().to_array(), [0, 0, 0, 0]);
+    assert_eq!(a.shift_elements_right::<5>().to_array(), [0, 0, 0, 0]);
+}
+
+#[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn interleave() {
     let a = Simd::from_array([0, 1, 2, 3, 4, 5, 6, 7]);
     let b = Simd::from_array([8, 9, 10, 11, 12, 13, 14, 15]);

--- a/crates/core_simd/tests/swizzle.rs
+++ b/crates/core_simd/tests/swizzle.rs
@@ -52,18 +52,18 @@ fn rotate() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn shift() {
     let a = Simd::from_array([1, 2, 3, 4]);
-    assert_eq!(a.shift_elements_left::<0>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.shift_elements_left::<1>().to_array(), [2, 3, 4, 0]);
-    assert_eq!(a.shift_elements_left::<2>().to_array(), [3, 4, 0, 0]);
-    assert_eq!(a.shift_elements_left::<3>().to_array(), [4, 0, 0, 0]);
-    assert_eq!(a.shift_elements_left::<4>().to_array(), [0, 0, 0, 0]);
-    assert_eq!(a.shift_elements_left::<5>().to_array(), [0, 0, 0, 0]);
-    assert_eq!(a.shift_elements_right::<0>().to_array(), [1, 2, 3, 4]);
-    assert_eq!(a.shift_elements_right::<1>().to_array(), [0, 1, 2, 3]);
-    assert_eq!(a.shift_elements_right::<2>().to_array(), [0, 0, 1, 2]);
-    assert_eq!(a.shift_elements_right::<3>().to_array(), [0, 0, 0, 1]);
-    assert_eq!(a.shift_elements_right::<4>().to_array(), [0, 0, 0, 0]);
-    assert_eq!(a.shift_elements_right::<5>().to_array(), [0, 0, 0, 0]);
+    assert_eq!(a.shift_elements_left::<0>(0).to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.shift_elements_left::<1>(0).to_array(), [2, 3, 4, 0]);
+    assert_eq!(a.shift_elements_left::<2>(9).to_array(), [3, 4, 9, 9]);
+    assert_eq!(a.shift_elements_left::<3>(8).to_array(), [4, 8, 8, 8]);
+    assert_eq!(a.shift_elements_left::<4>(7).to_array(), [7, 7, 7, 7]);
+    assert_eq!(a.shift_elements_left::<5>(6).to_array(), [6, 6, 6, 6]);
+    assert_eq!(a.shift_elements_right::<0>(0).to_array(), [1, 2, 3, 4]);
+    assert_eq!(a.shift_elements_right::<1>(0).to_array(), [0, 1, 2, 3]);
+    assert_eq!(a.shift_elements_right::<2>(-1).to_array(), [-1, -1, 1, 2]);
+    assert_eq!(a.shift_elements_right::<3>(-2).to_array(), [-2, -2, -2, 1]);
+    assert_eq!(a.shift_elements_right::<4>(-3).to_array(), [-3, -3, -3, -3]);
+    assert_eq!(a.shift_elements_right::<5>(-4).to_array(), [-4, -4, -4, -4]);
 }
 
 #[test]


### PR DESCRIPTION
This implementation was patterned after the pre-existing `rotate_elements_{left,right}` and is meant to supersede #112 from 2021. If this functionality is buried somewhere else in the API that I missed, please close with a note where I can find it.

The tests pass and the assembly looked reasonable on x86.
