### PR TITLE
Remove usize/isize `From` impls for vendor vector types

### DIFF
--- a/crates/core_simd/src/vendor/loongarch64.rs
+++ b/crates/core_simd/src/vendor/loongarch64.rs
@@ -24,8 +24,3 @@ from_transmute! { unsafe i64x2 => v2i64 }
 from_transmute! { unsafe i64x4 => v4i64 }
 from_transmute! { unsafe f64x2 => v2f64 }
 from_transmute! { unsafe f64x4 => v4f64 }
-
-from_transmute! { unsafe usizex2 => v2u64 }
-from_transmute! { unsafe usizex4 => v4u64 }
-from_transmute! { unsafe isizex2 => v2i64 }
-from_transmute! { unsafe isizex4 => v4i64 }

--- a/crates/core_simd/src/vendor/wasm32.rs
+++ b/crates/core_simd/src/vendor/wasm32.rs
@@ -14,17 +14,3 @@ from_transmute! { unsafe f32x4 => v128 }
 from_transmute! { unsafe u64x2 => v128 }
 from_transmute! { unsafe i64x2 => v128 }
 from_transmute! { unsafe f64x2 => v128 }
-
-#[cfg(target_pointer_width = "32")]
-mod p32 {
-    use super::*;
-    from_transmute! { unsafe usizex4 => v128 }
-    from_transmute! { unsafe isizex4 => v128 }
-}
-
-#[cfg(target_pointer_width = "64")]
-mod p64 {
-    use super::*;
-    from_transmute! { unsafe usizex2 => v128 }
-    from_transmute! { unsafe isizex2 => v128 }
-}

--- a/crates/core_simd/src/vendor/x86.rs
+++ b/crates/core_simd/src/vendor/x86.rs
@@ -39,25 +39,3 @@ from_transmute! { unsafe i64x8 => __m512i }
 from_transmute! { unsafe f64x2 => __m128d }
 from_transmute! { unsafe f64x4 => __m256d }
 from_transmute! { unsafe f64x8 => __m512d }
-
-#[cfg(target_pointer_width = "32")]
-mod p32 {
-    use super::*;
-    from_transmute! { unsafe usizex4 => __m128i }
-    from_transmute! { unsafe usizex8 => __m256i }
-    from_transmute! { unsafe Simd<usize, 16> => __m512i }
-    from_transmute! { unsafe isizex4 => __m128i }
-    from_transmute! { unsafe isizex8 => __m256i }
-    from_transmute! { unsafe Simd<isize, 16> => __m512i }
-}
-
-#[cfg(target_pointer_width = "64")]
-mod p64 {
-    use super::*;
-    from_transmute! { unsafe usizex2 => __m128i }
-    from_transmute! { unsafe usizex4 => __m256i }
-    from_transmute! { unsafe usizex8 => __m512i }
-    from_transmute! { unsafe isizex2 => __m128i }
-    from_transmute! { unsafe isizex4 => __m256i }
-    from_transmute! { unsafe isizex8 => __m512i }
-}


### PR DESCRIPTION
Remove `usize`/`isize` impls from
- `loongarch64.rs`
- `wasm32.rs`
- `x86.rs`

Closes #462

---

The `loongarch64` one isn't gated behind a `cfg` but deleted it to follow the spirit of the change.
I can back that out if needed.