### PR TITLE
Make `Mask::splat` const

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -139,7 +139,8 @@ where
 {
     /// Constructs a mask by setting all elements to the given value.
     #[inline]
-    pub fn splat(value: bool) -> Self {
+    #[rustc_const_unstable(feature = "portable_simd", issue = "86656")]
+    pub const fn splat(value: bool) -> Self {
         Self(mask_impl::Mask::splat(value))
     }
 

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -78,17 +78,16 @@ where
 {
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub(crate) fn splat(value: bool) -> Self {
-        let mut mask = <LaneCount<N> as SupportedLaneCount>::BitMask::default();
-        if value {
-            mask.as_mut().fill(u8::MAX)
-        } else {
-            mask.as_mut().fill(u8::MIN)
-        }
-        if N % 8 > 0 {
-            *mask.as_mut().last_mut().unwrap() &= u8::MAX >> (8 - N % 8);
-        }
-        Self(mask, PhantomData)
+    #[rustc_const_unstable(feature = "portable_simd", issue = "86656")]
+    pub(crate) const fn splat(value: bool) -> Self {
+        Self(
+            if value {
+                <LaneCount<N> as SupportedLaneCount>::FULL_BIT_MASK
+            } else {
+                <LaneCount<N> as SupportedLaneCount>::EMPTY_BIT_MASK
+            },
+            PhantomData,
+        )
     }
 
     #[inline]
@@ -131,7 +130,7 @@ where
 
     #[inline]
     pub(crate) fn from_bitmask_integer(bitmask: u64) -> Self {
-        let mut bytes = <LaneCount<N> as SupportedLaneCount>::BitMask::default();
+        let mut bytes = <LaneCount<N> as SupportedLaneCount>::BitMask::EMPTY_BIT_MASK;
         let len = bytes.as_mut().len();
         bytes
             .as_mut()

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -102,7 +102,8 @@ where
 {
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub(crate) fn splat(value: bool) -> Self {
+    #[rustc_const_unstable(feature = "portable_simd", issue = "86656")]
+    pub(crate) const fn splat(value: bool) -> Self {
         Self(Simd::splat(if value { T::TRUE } else { T::FALSE }))
     }
 


### PR DESCRIPTION
This is a small step toward making more methods `const`.

While removing the `Default` bound was not *strictly* necessary, I found that it made sense to do given the implementation. Better to mention that it's not used here in the bounds than leave it in.

There are probably other mask methods that could be made const with minimal changes, but I didn't want to touch anything that used intrinsics and/or litter everything with `const_eval_select` to make it work.