### PR TITLE
Add `'static` bound to element traits

### DIFF
--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -5,7 +5,7 @@ use crate::simd::{
 };
 
 /// Operations on SIMD vectors of floats.
-pub trait SimdFloat: Copy + Sealed {
+pub trait SimdFloat: 'static + Copy + Sealed {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 

--- a/crates/core_simd/src/simd/num/int.rs
+++ b/crates/core_simd/src/simd/num/int.rs
@@ -5,7 +5,7 @@ use crate::simd::{
 };
 
 /// Operations on SIMD vectors of signed integers.
-pub trait SimdInt: Copy + Sealed {
+pub trait SimdInt: 'static + Copy + Sealed {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 

--- a/crates/core_simd/src/simd/num/uint.rs
+++ b/crates/core_simd/src/simd/num/uint.rs
@@ -2,7 +2,7 @@ use super::sealed::Sealed;
 use crate::simd::{LaneCount, Simd, SimdCast, SimdElement, SupportedLaneCount, cmp::SimdOrd};
 
 /// Operations on SIMD vectors of unsigned integers.
-pub trait SimdUint: Copy + Sealed {
+pub trait SimdUint: 'static + Copy + Sealed {
     /// Scalar type contained by this SIMD vector type.
     type Scalar;
 

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -1103,7 +1103,7 @@ use sealed::Sealed;
 /// Strictly, it is valid to impl if the vector will not be miscompiled.
 /// Practically, it is user-unfriendly to impl it if the vector won't compile,
 /// even when no soundness guarantees are broken by allowing the user to try.
-pub unsafe trait SimdElement: Sealed + Copy {
+pub unsafe trait SimdElement: 'static + Copy + Sealed {
     /// The mask element type corresponding to this element type.
     type Mask: MaskElement;
 }


### PR DESCRIPTION
Since these traits may eventually become bounds for fallback intrinsics (see: #467) it's helpful to not have to explicitly add `'static` when these bounds are already present. We know that the elements are primitives, and this further clarifies that.