### PR TITLE
Fix compilation for AVX512

### DIFF
--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -130,7 +130,7 @@ where
 
     #[inline]
     pub(crate) fn from_bitmask_integer(bitmask: u64) -> Self {
-        let mut bytes = <LaneCount<N> as SupportedLaneCount>::BitMask::EMPTY_BIT_MASK;
+        let mut bytes = <LaneCount<N> as SupportedLaneCount>::EMPTY_BIT_MASK;
         let len = bytes.as_mut().len();
         bytes
             .as_mut()


### PR DESCRIPTION
When compiling for AVX512, the following error occurs in bitmask.rs:
```
error[E0599]: no associated item named `EMPTY_BIT_MASK` found for associated type `<lane_count::LaneCount<N> as lane_count::SupportedLaneCount>::BitMask` in the current scope
   --> /home/ryan/.cargo/git/checkouts/portable-simd-8edd7e7a3748e100/3439347/crates/core_simd/src/masks/bitmask.rs:133:72
    |
133 |         let mut bytes = <LaneCount<N> as SupportedLaneCount>::BitMask::EMPTY_BIT_MASK;
    |                                                                        ^^^^^^^^^^^^^^ associated item not found in `<lane_count::LaneCount<N> as lane_count::SupportedLaneCount>::BitMask`

For more information about this error, try `rustc --explain E0599`.
```
This just fixes the reference to EMPTY_BIT_MASK to match everywhere else.