### PR TITLE
Rename `int` to `simd` in `Mask` functions

### DIFF
--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -157,7 +157,7 @@ where
             let bytes: [u8; N] = mem::transmute_copy(&array);
             let bools: Simd<i8, N> =
                 core::intrinsics::simd::simd_ne(Simd::from_array(bytes), Simd::splat(0u8));
-            Mask::from_int_unchecked(core::intrinsics::simd::simd_cast(bools))
+            Mask::from_simd_unchecked(core::intrinsics::simd::simd_cast(bools))
         }
     }
 
@@ -188,11 +188,11 @@ where
     /// All elements must be either 0 or -1.
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub unsafe fn from_int_unchecked(value: Simd<T, N>) -> Self {
+    pub unsafe fn from_simd_unchecked(value: Simd<T, N>) -> Self {
         // Safety: the caller must confirm this invariant
         unsafe {
             core::intrinsics::assume(<T as Sealed>::valid(value));
-            Self(mask_impl::Mask::from_int_unchecked(value))
+            Self(mask_impl::Mask::from_simd_unchecked(value))
         }
     }
 
@@ -207,7 +207,7 @@ where
     pub fn from_simd(value: Simd<T, N>) -> Self {
         assert!(T::valid(value), "all values must be either 0 or -1",);
         // Safety: the validity has been checked
-        unsafe { Self::from_int_unchecked(value) }
+        unsafe { Self::from_simd_unchecked(value) }
     }
 
     /// Converts the mask to a vector of integers, where 0 represents `false` and -1

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -175,7 +175,7 @@ where
         // This would be hypothetically valid as an "in-place" transmute,
         // but these are "dependently-sized" types, so copy elision it is!
         unsafe {
-            let mut bytes: Simd<i8, N> = core::intrinsics::simd::simd_cast(self.to_int());
+            let mut bytes: Simd<i8, N> = core::intrinsics::simd::simd_cast(self.to_simd());
             bytes &= Simd::splat(1i8);
             mem::transmute_copy(&bytes)
         }
@@ -214,8 +214,8 @@ where
     /// represents `true`.
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original value"]
-    pub fn to_int(self) -> Simd<T, N> {
-        self.0.to_int()
+    pub fn to_simd(self) -> Simd<T, N> {
+        self.0.to_simd()
     }
 
     /// Converts the mask to a mask of any other element size.
@@ -352,7 +352,7 @@ where
         // Safety: the input and output are integer vectors
         let index: Simd<T, N> = unsafe { core::intrinsics::simd::simd_cast(index) };
 
-        let masked_index = self.select(index, Self::splat(true).to_int());
+        let masked_index = self.select(index, Self::splat(true).to_simd());
 
         // Safety: the input and output are integer vectors
         let masked_index: Simd<T::Unsigned, N> =

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -204,7 +204,7 @@ where
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     #[track_caller]
-    pub fn from_int(value: Simd<T, N>) -> Self {
+    pub fn from_simd(value: Simd<T, N>) -> Self {
         assert!(T::valid(value), "all values must be either 0 or -1",);
         // Safety: the validity has been checked
         unsafe { Self::from_int_unchecked(value) }

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -105,7 +105,7 @@ where
 
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original value"]
-    pub(crate) fn to_int(self) -> Simd<T, N> {
+    pub(crate) fn to_simd(self) -> Simd<T, N> {
         unsafe {
             core::intrinsics::simd::simd_select_bitmask(
                 self.0,

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -117,7 +117,7 @@ where
 
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub(crate) unsafe fn from_int_unchecked(value: Simd<T, N>) -> Self {
+    pub(crate) unsafe fn from_simd_unchecked(value: Simd<T, N>) -> Self {
         unsafe { Self(core::intrinsics::simd::simd_bitmask(value), PhantomData) }
     }
 

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -126,7 +126,7 @@ where
 
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
-    pub(crate) unsafe fn from_int_unchecked(value: Simd<T, N>) -> Self {
+    pub(crate) unsafe fn from_simd_unchecked(value: Simd<T, N>) -> Self {
         Self(value)
     }
 
@@ -180,7 +180,7 @@ where
         };
 
         // SAFETY: `mask` only contains `T::TRUE` or `T::FALSE`
-        unsafe { Self::from_int_unchecked(mask.resize::<N>(T::FALSE)) }
+        unsafe { Self::from_simd_unchecked(mask.resize::<N>(T::FALSE)) }
     }
 
     #[inline]

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -120,7 +120,7 @@ where
 
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original value"]
-    pub(crate) fn to_int(self) -> Simd<T, N> {
+    pub(crate) fn to_simd(self) -> Simd<T, N> {
         self.0
     }
 
@@ -145,7 +145,7 @@ where
     where
         LaneCount<M>: SupportedLaneCount,
     {
-        let resized = self.to_int().resize::<M>(T::FALSE);
+        let resized = self.to_simd().resize::<M>(T::FALSE);
 
         // Safety: `resized` is an integer vector with length M, which must match T
         let bitmask: U = unsafe { core::intrinsics::simd::simd_bitmask(resized) };
@@ -223,14 +223,14 @@ where
     #[must_use = "method returns a new bool and does not mutate the original value"]
     pub(crate) fn any(self) -> bool {
         // Safety: use `self` as an integer vector
-        unsafe { core::intrinsics::simd::simd_reduce_any(self.to_int()) }
+        unsafe { core::intrinsics::simd::simd_reduce_any(self.to_simd()) }
     }
 
     #[inline]
     #[must_use = "method returns a new bool and does not mutate the original value"]
     pub(crate) fn all(self) -> bool {
         // Safety: use `self` as an integer vector
-        unsafe { core::intrinsics::simd::simd_reduce_all(self.to_int()) }
+        unsafe { core::intrinsics::simd::simd_reduce_all(self.to_simd()) }
     }
 }
 

--- a/crates/core_simd/src/select.rs
+++ b/crates/core_simd/src/select.rs
@@ -28,7 +28,7 @@ where
     {
         // Safety: The mask has been cast to a vector of integers,
         // and the operands to select between are vectors of the same type and length.
-        unsafe { core::intrinsics::simd::simd_select(self.to_int(), true_values, false_values) }
+        unsafe { core::intrinsics::simd::simd_select(self.to_simd(), true_values, false_values) }
     }
 
     /// Choose elements from two masks.

--- a/crates/core_simd/src/simd/cmp/eq.rs
+++ b/crates/core_simd/src/simd/cmp/eq.rs
@@ -59,14 +59,14 @@ macro_rules! impl_mask {
             fn simd_eq(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_eq(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_eq(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_ne(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ne(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ne(self.to_simd(), other.to_simd())) }
             }
         }
         )*

--- a/crates/core_simd/src/simd/cmp/eq.rs
+++ b/crates/core_simd/src/simd/cmp/eq.rs
@@ -30,14 +30,14 @@ macro_rules! impl_number {
             fn simd_eq(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_eq(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_eq(self, other)) }
             }
 
             #[inline]
             fn simd_ne(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_ne(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_ne(self, other)) }
             }
         }
         )*
@@ -59,14 +59,14 @@ macro_rules! impl_mask {
             fn simd_eq(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_eq(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_eq(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_ne(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ne(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_ne(self.to_simd(), other.to_simd())) }
             }
         }
         )*

--- a/crates/core_simd/src/simd/cmp/ord.rs
+++ b/crates/core_simd/src/simd/cmp/ord.rs
@@ -163,28 +163,28 @@ macro_rules! impl_mask {
             fn simd_lt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_lt(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_lt(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_le(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_le(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_le(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_gt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_gt(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_gt(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_ge(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ge(self.to_int(), other.to_int())) }
+                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ge(self.to_simd(), other.to_simd())) }
             }
         }
 

--- a/crates/core_simd/src/simd/cmp/ord.rs
+++ b/crates/core_simd/src/simd/cmp/ord.rs
@@ -56,28 +56,28 @@ macro_rules! impl_integer {
             fn simd_lt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_lt(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_lt(self, other)) }
             }
 
             #[inline]
             fn simd_le(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_le(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_le(self, other)) }
             }
 
             #[inline]
             fn simd_gt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_gt(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_gt(self, other)) }
             }
 
             #[inline]
             fn simd_ge(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_ge(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_ge(self, other)) }
             }
         }
 
@@ -122,28 +122,28 @@ macro_rules! impl_float {
             fn simd_lt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_lt(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_lt(self, other)) }
             }
 
             #[inline]
             fn simd_le(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_le(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_le(self, other)) }
             }
 
             #[inline]
             fn simd_gt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_gt(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_gt(self, other)) }
             }
 
             #[inline]
             fn simd_ge(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Mask::from_int_unchecked(core::intrinsics::simd::simd_ge(self, other)) }
+                unsafe { Mask::from_simd_unchecked(core::intrinsics::simd::simd_ge(self, other)) }
             }
         }
         )*
@@ -163,28 +163,28 @@ macro_rules! impl_mask {
             fn simd_lt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_lt(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_lt(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_le(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_le(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_le(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_gt(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_gt(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_gt(self.to_simd(), other.to_simd())) }
             }
 
             #[inline]
             fn simd_ge(self, other: Self) -> Self::Mask {
                 // Safety: `self` is a vector, and the result of the comparison
                 // is always a valid mask.
-                unsafe { Self::from_int_unchecked(core::intrinsics::simd::simd_ge(self.to_simd(), other.to_simd())) }
+                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_ge(self.to_simd(), other.to_simd())) }
             }
         }
 

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -165,7 +165,7 @@ pub trait Swizzle<const N: usize> {
         LaneCount<M>: SupportedLaneCount,
     {
         // SAFETY: all elements of this mask come from another mask
-        unsafe { Mask::from_int_unchecked(Self::swizzle(mask.to_int())) }
+        unsafe { Mask::from_int_unchecked(Self::swizzle(mask.to_simd())) }
     }
 
     /// Creates a new mask from the elements of `first` and `second`.
@@ -181,7 +181,7 @@ pub trait Swizzle<const N: usize> {
         LaneCount<M>: SupportedLaneCount,
     {
         // SAFETY: all elements of this mask come from another mask
-        unsafe { Mask::from_int_unchecked(Self::concat_swizzle(first.to_int(), second.to_int())) }
+        unsafe { Mask::from_int_unchecked(Self::concat_swizzle(first.to_simd(), second.to_simd())) }
     }
 }
 
@@ -524,7 +524,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn reverse(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().reverse()) }
+        unsafe { Self::from_int_unchecked(self.to_simd().reverse()) }
     }
 
     /// Rotates the mask such that the first `OFFSET` elements of the slice move to the end
@@ -534,7 +534,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().rotate_elements_left::<OFFSET>()) }
+        unsafe { Self::from_int_unchecked(self.to_simd().rotate_elements_left::<OFFSET>()) }
     }
 
     /// Rotates the mask such that the first `self.len() - OFFSET` elements of the mask move to
@@ -544,7 +544,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_int().rotate_elements_right::<OFFSET>()) }
+        unsafe { Self::from_int_unchecked(self.to_simd().rotate_elements_right::<OFFSET>()) }
     }
 
     /// Shifts the mask elements to the left by `OFFSET`, filling in with
@@ -554,7 +554,7 @@ where
     pub fn shift_elements_left<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_int_unchecked(self.to_int().shift_elements_left::<OFFSET>(if padding {
+            Self::from_int_unchecked(self.to_simd().shift_elements_left::<OFFSET>(if padding {
                 T::TRUE
             } else {
                 T::FALSE
@@ -569,7 +569,7 @@ where
     pub fn shift_elements_right<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_int_unchecked(self.to_int().shift_elements_right::<OFFSET>(if padding {
+            Self::from_int_unchecked(self.to_simd().shift_elements_right::<OFFSET>(if padding {
                 T::TRUE
             } else {
                 T::FALSE
@@ -598,7 +598,7 @@ where
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn interleave(self, other: Self) -> (Self, Self) {
-        let (lo, hi) = self.to_int().interleave(other.to_int());
+        let (lo, hi) = self.to_simd().interleave(other.to_simd());
         // Safety: swizzles are safe for masks
         unsafe { (Self::from_int_unchecked(lo), Self::from_int_unchecked(hi)) }
     }
@@ -627,7 +627,7 @@ where
     #[inline]
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn deinterleave(self, other: Self) -> (Self, Self) {
-        let (even, odd) = self.to_int().deinterleave(other.to_int());
+        let (even, odd) = self.to_simd().deinterleave(other.to_simd());
         // Safety: swizzles are safe for masks
         unsafe {
             (
@@ -659,7 +659,7 @@ where
     {
         // Safety: swizzles are safe for masks
         unsafe {
-            Mask::<T, M>::from_int_unchecked(self.to_int().resize::<M>(if value {
+            Mask::<T, M>::from_int_unchecked(self.to_simd().resize::<M>(if value {
                 T::TRUE
             } else {
                 T::FALSE
@@ -684,6 +684,6 @@ where
         LaneCount<LEN>: SupportedLaneCount,
     {
         // Safety: swizzles are safe for masks
-        unsafe { Mask::<T, LEN>::from_int_unchecked(self.to_int().extract::<START, LEN>()) }
+        unsafe { Mask::<T, LEN>::from_int_unchecked(self.to_simd().extract::<START, LEN>()) }
     }
 }

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -165,7 +165,7 @@ pub trait Swizzle<const N: usize> {
         LaneCount<M>: SupportedLaneCount,
     {
         // SAFETY: all elements of this mask come from another mask
-        unsafe { Mask::from_int_unchecked(Self::swizzle(mask.to_simd())) }
+        unsafe { Mask::from_simd_unchecked(Self::swizzle(mask.to_simd())) }
     }
 
     /// Creates a new mask from the elements of `first` and `second`.
@@ -181,7 +181,9 @@ pub trait Swizzle<const N: usize> {
         LaneCount<M>: SupportedLaneCount,
     {
         // SAFETY: all elements of this mask come from another mask
-        unsafe { Mask::from_int_unchecked(Self::concat_swizzle(first.to_simd(), second.to_simd())) }
+        unsafe {
+            Mask::from_simd_unchecked(Self::concat_swizzle(first.to_simd(), second.to_simd()))
+        }
     }
 }
 
@@ -524,7 +526,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn reverse(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_simd().reverse()) }
+        unsafe { Self::from_simd_unchecked(self.to_simd().reverse()) }
     }
 
     /// Rotates the mask such that the first `OFFSET` elements of the slice move to the end
@@ -534,7 +536,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn rotate_elements_left<const OFFSET: usize>(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_simd().rotate_elements_left::<OFFSET>()) }
+        unsafe { Self::from_simd_unchecked(self.to_simd().rotate_elements_left::<OFFSET>()) }
     }
 
     /// Rotates the mask such that the first `self.len() - OFFSET` elements of the mask move to
@@ -544,7 +546,7 @@ where
     #[must_use = "method returns a new vector and does not mutate the original inputs"]
     pub fn rotate_elements_right<const OFFSET: usize>(self) -> Self {
         // Safety: swizzles are safe for masks
-        unsafe { Self::from_int_unchecked(self.to_simd().rotate_elements_right::<OFFSET>()) }
+        unsafe { Self::from_simd_unchecked(self.to_simd().rotate_elements_right::<OFFSET>()) }
     }
 
     /// Shifts the mask elements to the left by `OFFSET`, filling in with
@@ -554,7 +556,7 @@ where
     pub fn shift_elements_left<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_int_unchecked(self.to_simd().shift_elements_left::<OFFSET>(if padding {
+            Self::from_simd_unchecked(self.to_simd().shift_elements_left::<OFFSET>(if padding {
                 T::TRUE
             } else {
                 T::FALSE
@@ -569,7 +571,7 @@ where
     pub fn shift_elements_right<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_int_unchecked(self.to_simd().shift_elements_right::<OFFSET>(if padding {
+            Self::from_simd_unchecked(self.to_simd().shift_elements_right::<OFFSET>(if padding {
                 T::TRUE
             } else {
                 T::FALSE
@@ -600,7 +602,7 @@ where
     pub fn interleave(self, other: Self) -> (Self, Self) {
         let (lo, hi) = self.to_simd().interleave(other.to_simd());
         // Safety: swizzles are safe for masks
-        unsafe { (Self::from_int_unchecked(lo), Self::from_int_unchecked(hi)) }
+        unsafe { (Self::from_simd_unchecked(lo), Self::from_simd_unchecked(hi)) }
     }
 
     /// Deinterleave two masks.
@@ -631,8 +633,8 @@ where
         // Safety: swizzles are safe for masks
         unsafe {
             (
-                Self::from_int_unchecked(even),
-                Self::from_int_unchecked(odd),
+                Self::from_simd_unchecked(even),
+                Self::from_simd_unchecked(odd),
             )
         }
     }
@@ -659,7 +661,7 @@ where
     {
         // Safety: swizzles are safe for masks
         unsafe {
-            Mask::<T, M>::from_int_unchecked(self.to_simd().resize::<M>(if value {
+            Mask::<T, M>::from_simd_unchecked(self.to_simd().resize::<M>(if value {
                 T::TRUE
             } else {
                 T::FALSE
@@ -684,6 +686,6 @@ where
         LaneCount<LEN>: SupportedLaneCount,
     {
         // Safety: swizzles are safe for masks
-        unsafe { Mask::<T, LEN>::from_int_unchecked(self.to_simd().extract::<START, LEN>()) }
+        unsafe { Mask::<T, LEN>::from_simd_unchecked(self.to_simd().extract::<START, LEN>()) }
     }
 }

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -474,7 +474,7 @@ where
         or: Self,
     ) -> Self {
         // SAFETY: The safety of reading elements through `ptr` is ensured by the caller.
-        unsafe { core::intrinsics::simd::simd_masked_load(enable.to_int(), ptr, or) }
+        unsafe { core::intrinsics::simd::simd_masked_load(enable.to_simd(), ptr, or) }
     }
 
     /// Reads from potentially discontiguous indices in `slice` to construct a SIMD vector.
@@ -652,7 +652,7 @@ where
         or: Self,
     ) -> Self {
         // Safety: The caller is responsible for upholding all invariants
-        unsafe { core::intrinsics::simd::simd_gather(or, source, enable.to_int()) }
+        unsafe { core::intrinsics::simd::simd_gather(or, source, enable.to_simd()) }
     }
 
     /// Conditionally write contiguous elements to `slice`. The `enable` mask controls
@@ -723,7 +723,7 @@ where
     #[inline]
     pub unsafe fn store_select_ptr(self, ptr: *mut T, enable: Mask<<T as SimdElement>::Mask, N>) {
         // SAFETY: The safety of writing elements through `ptr` is ensured by the caller.
-        unsafe { core::intrinsics::simd::simd_masked_store(enable.to_int(), ptr, self) }
+        unsafe { core::intrinsics::simd::simd_masked_store(enable.to_simd(), ptr, self) }
     }
 
     /// Writes the values in a SIMD vector to potentially discontiguous indices in `slice`.
@@ -882,7 +882,7 @@ where
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub unsafe fn scatter_select_ptr(self, dest: Simd<*mut T, N>, enable: Mask<isize, N>) {
         // Safety: The caller is responsible for upholding all invariants
-        unsafe { core::intrinsics::simd::simd_scatter(self, dest, enable.to_int()) }
+        unsafe { core::intrinsics::simd::simd_scatter(self, dest, enable.to_simd()) }
     }
 }
 

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -926,7 +926,7 @@ where
         let mask = unsafe {
             let tfvec: Simd<<T as SimdElement>::Mask, N> =
                 core::intrinsics::simd::simd_eq(*self, *other);
-            Mask::from_int_unchecked(tfvec)
+            Mask::from_simd_unchecked(tfvec)
         };
 
         // Two vectors are equal if all elements are equal when compared elementwise
@@ -940,7 +940,7 @@ where
         let mask = unsafe {
             let tfvec: Simd<<T as SimdElement>::Mask, N> =
                 core::intrinsics::simd::simd_ne(*self, *other);
-            Mask::from_int_unchecked(tfvec)
+            Mask::from_simd_unchecked(tfvec)
         };
 
         // Two vectors are non-equal if any elements are non-equal when compared elementwise

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -65,7 +65,7 @@ macro_rules! test_mask_api {
             fn roundtrip_int_conversion() {
                 let values = [true, false, false, true, false, false, true, false];
                 let mask = Mask::<$type, 8>::from_array(values);
-                let int = mask.to_int();
+                let int = mask.to_simd();
                 assert_eq!(int.to_array(), [-1, 0, 0, -1, 0, 0, -1, 0]);
                 assert_eq!(Mask::<$type, 8>::from_int(int), mask);
             }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -67,7 +67,7 @@ macro_rules! test_mask_api {
                 let mask = Mask::<$type, 8>::from_array(values);
                 let int = mask.to_simd();
                 assert_eq!(int.to_array(), [-1, 0, 0, -1, 0, 0, -1, 0]);
-                assert_eq!(Mask::<$type, 8>::from_int(int), mask);
+                assert_eq!(Mask::<$type, 8>::from_simd(int), mask);
             }
 
             #[test]


### PR DESCRIPTION
After this PR, the remaining uses of `to_int` are for float to int conversions.

Renaming
`from_int` -> `from_simd`
`from_int_unchecked` -> `from_simd_unchecked`
`to_int` -> `to_simd`

Closes https://github.com/rust-lang/portable-simd/issues/477
