### PR TITLE
Mask element v2

### DIFF
--- a/crates/core_simd/src/simd/cmp/eq.rs
+++ b/crates/core_simd/src/simd/cmp/eq.rs
@@ -24,7 +24,7 @@ macro_rules! impl_number {
         where
             LaneCount<N>: SupportedLaneCount,
         {
-            type Mask = Mask<<$number as SimdElement>::Mask, N>;
+            type Mask = Mask<$number, N>;
 
             #[inline]
             fn simd_eq(self, other: Self) -> Self::Mask {
@@ -46,49 +46,51 @@ macro_rules! impl_number {
 
 impl_number! { f32, f64, u8, u16, u32, u64, usize, i8, i16, i32, i64, isize }
 
-macro_rules! impl_mask {
-    { $($integer:ty),* } => {
-        $(
-        impl<const N: usize> SimdPartialEq for Mask<$integer, N>
-        where
-            LaneCount<N>: SupportedLaneCount,
-        {
-            type Mask = Self;
+// Masks compare lane-wise by comparing their underlying integer representations
+impl<T, const N: usize> SimdPartialEq for Mask<T, N>
+where
+    T: SimdElement,
+    LaneCount<N>: SupportedLaneCount,
+{
+    type Mask = Self;
 
-            #[inline]
-            fn simd_eq(self, other: Self) -> Self::Mask {
-                // Safety: `self` is a vector, and the result of the comparison
-                // is always a valid mask.
-                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_eq(self.to_simd(), other.to_simd())) }
-            }
-
-            #[inline]
-            fn simd_ne(self, other: Self) -> Self::Mask {
-                // Safety: `self` is a vector, and the result of the comparison
-                // is always a valid mask.
-                unsafe { Self::from_simd_unchecked(core::intrinsics::simd::simd_ne(self.to_simd(), other.to_simd())) }
-            }
+    #[inline]
+    fn simd_eq(self, other: Self) -> Self::Mask {
+        // Safety: `self` is a vector, and the result of the comparison is always a valid mask.
+        unsafe {
+            Self::from_simd_unchecked(core::intrinsics::simd::simd_eq(
+                self.to_simd(),
+                other.to_simd(),
+            ))
         }
-        )*
+    }
+
+    #[inline]
+    fn simd_ne(self, other: Self) -> Self::Mask {
+        // Safety: `self` is a vector, and the result of the comparison is always a valid mask.
+        unsafe {
+            Self::from_simd_unchecked(core::intrinsics::simd::simd_ne(
+                self.to_simd(),
+                other.to_simd(),
+            ))
+        }
     }
 }
-
-impl_mask! { i8, i16, i32, i64, isize }
 
 impl<T, const N: usize> SimdPartialEq for Simd<*const T, N>
 where
     LaneCount<N>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, N>;
+    type Mask = Mask<*const T, N>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {
-        self.addr().simd_eq(other.addr())
+        self.addr().simd_eq(other.addr()).cast::<*const T>()
     }
 
     #[inline]
     fn simd_ne(self, other: Self) -> Self::Mask {
-        self.addr().simd_ne(other.addr())
+        self.addr().simd_ne(other.addr()).cast::<*const T>()
     }
 }
 
@@ -96,15 +98,15 @@ impl<T, const N: usize> SimdPartialEq for Simd<*mut T, N>
 where
     LaneCount<N>: SupportedLaneCount,
 {
-    type Mask = Mask<isize, N>;
+    type Mask = Mask<*mut T, N>;
 
     #[inline]
     fn simd_eq(self, other: Self) -> Self::Mask {
-        self.addr().simd_eq(other.addr())
+        self.addr().simd_eq(other.addr()).cast::<*mut T>()
     }
 
     #[inline]
     fn simd_ne(self, other: Self) -> Self::Mask {
-        self.addr().simd_ne(other.addr())
+        self.addr().simd_ne(other.addr()).cast::<*mut T>()
     }
 }

--- a/crates/core_simd/src/simd/num/int.rs
+++ b/crates/core_simd/src/simd/num/int.rs
@@ -251,7 +251,7 @@ macro_rules! impl_trait {
         where
             LaneCount<N>: SupportedLaneCount,
         {
-            type Mask = Mask<<$ty as SimdElement>::Mask, N>;
+            type Mask = Mask<$ty, N>;
             type Scalar = $ty;
             type Unsigned = Simd<$unsigned, N>;
             type Cast<T: SimdElement> = Simd<T, N>;

--- a/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -98,7 +98,7 @@ where
     type Isize = Simd<isize, N>;
     type CastPtr<U> = Simd<*const U, N>;
     type MutPtr = Simd<*mut T, N>;
-    type Mask = Mask<isize, N>;
+    type Mask = Mask<*const T, N>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -95,7 +95,7 @@ where
     type Isize = Simd<isize, N>;
     type CastPtr<U> = Simd<*mut U, N>;
     type ConstPtr = Simd<*const T, N>;
-    type Mask = Mask<isize, N>;
+    type Mask = Mask<*mut T, N>;
 
     #[inline]
     fn is_null(self) -> Self::Mask {

--- a/crates/core_simd/src/swizzle.rs
+++ b/crates/core_simd/src/swizzle.rs
@@ -1,4 +1,4 @@
-use crate::simd::{LaneCount, Mask, MaskElement, Simd, SimdElement, SupportedLaneCount};
+use crate::simd::{LaneCount, Mask, Simd, SimdElement, SupportedLaneCount};
 
 /// Constructs a new SIMD vector by copying elements from selected elements in other vectors.
 ///
@@ -160,7 +160,7 @@ pub trait Swizzle<const N: usize> {
     #[must_use = "method returns a new mask and does not mutate the original inputs"]
     fn swizzle_mask<T, const M: usize>(mask: Mask<T, M>) -> Mask<T, N>
     where
-        T: MaskElement,
+        T: SimdElement,
         LaneCount<N>: SupportedLaneCount,
         LaneCount<M>: SupportedLaneCount,
     {
@@ -176,7 +176,7 @@ pub trait Swizzle<const N: usize> {
     #[must_use = "method returns a new mask and does not mutate the original inputs"]
     fn concat_swizzle_mask<T, const M: usize>(first: Mask<T, M>, second: Mask<T, M>) -> Mask<T, N>
     where
-        T: MaskElement,
+        T: SimdElement,
         LaneCount<N>: SupportedLaneCount,
         LaneCount<M>: SupportedLaneCount,
     {
@@ -518,7 +518,7 @@ where
 
 impl<T, const N: usize> Mask<T, N>
 where
-    T: MaskElement,
+    T: SimdElement,
     LaneCount<N>: SupportedLaneCount,
 {
     /// Reverse the order of the elements in the mask.
@@ -556,11 +556,8 @@ where
     pub fn shift_elements_left<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_simd_unchecked(self.to_simd().shift_elements_left::<OFFSET>(if padding {
-                T::TRUE
-            } else {
-                T::FALSE
-            }))
+            let padding = Mask::<T, 1>::splat(padding).to_simd()[0];
+            Self::from_simd_unchecked(self.to_simd().shift_elements_left::<OFFSET>(padding))
         }
     }
 
@@ -571,11 +568,8 @@ where
     pub fn shift_elements_right<const OFFSET: usize>(self, padding: bool) -> Self {
         // Safety: swizzles are safe for masks
         unsafe {
-            Self::from_simd_unchecked(self.to_simd().shift_elements_right::<OFFSET>(if padding {
-                T::TRUE
-            } else {
-                T::FALSE
-            }))
+            let padding = Mask::<T, 1>::splat(padding).to_simd()[0];
+            Self::from_simd_unchecked(self.to_simd().shift_elements_right::<OFFSET>(padding))
         }
     }
 
@@ -661,11 +655,8 @@ where
     {
         // Safety: swizzles are safe for masks
         unsafe {
-            Mask::<T, M>::from_simd_unchecked(self.to_simd().resize::<M>(if value {
-                T::TRUE
-            } else {
-                T::FALSE
-            }))
+            let padding = Mask::<T, 1>::splat(value).to_simd()[0];
+            Mask::<T, M>::from_simd_unchecked(self.to_simd().resize::<M>(padding))
         }
     }
 

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -399,7 +399,7 @@ where
     /// ```
     #[must_use]
     #[inline]
-    pub fn load_select_or_default(slice: &[T], enable: Mask<<T as SimdElement>::Mask, N>) -> Self
+    pub fn load_select_or_default(slice: &[T], enable: Mask<T, N>) -> Self
     where
         T: Default,
     {
@@ -427,11 +427,7 @@ where
     /// ```
     #[must_use]
     #[inline]
-    pub fn load_select(
-        slice: &[T],
-        mut enable: Mask<<T as SimdElement>::Mask, N>,
-        or: Self,
-    ) -> Self {
+    pub fn load_select(slice: &[T], mut enable: Mask<T, N>, or: Self) -> Self {
         enable &= mask_up_to(slice.len());
         // SAFETY: We performed the bounds check by updating the mask. &[T] is properly aligned to
         // the element.
@@ -448,11 +444,7 @@ where
     /// Enabled loads must not exceed the length of `slice`.
     #[must_use]
     #[inline]
-    pub unsafe fn load_select_unchecked(
-        slice: &[T],
-        enable: Mask<<T as SimdElement>::Mask, N>,
-        or: Self,
-    ) -> Self {
+    pub unsafe fn load_select_unchecked(slice: &[T], enable: Mask<T, N>, or: Self) -> Self {
         let ptr = slice.as_ptr();
         // SAFETY: The safety of reading elements from `slice` is ensured by the caller.
         unsafe { Self::load_select_ptr(ptr, enable, or) }
@@ -468,11 +460,7 @@ where
     /// Enabled `ptr` elements must be safe to read as if by `std::ptr::read`.
     #[must_use]
     #[inline]
-    pub unsafe fn load_select_ptr(
-        ptr: *const T,
-        enable: Mask<<T as SimdElement>::Mask, N>,
-        or: Self,
-    ) -> Self {
+    pub unsafe fn load_select_ptr(ptr: *const T, enable: Mask<T, N>, or: Self) -> Self {
         // SAFETY: The safety of reading elements through `ptr` is ensured by the caller.
         unsafe { core::intrinsics::simd::simd_masked_load(enable.to_simd(), ptr, or) }
     }
@@ -539,11 +527,11 @@ where
     #[inline]
     pub fn gather_select(
         slice: &[T],
-        enable: Mask<isize, N>,
+        enable: Mask<usize, N>,
         idxs: Simd<usize, N>,
         or: Self,
     ) -> Self {
-        let enable: Mask<isize, N> = enable & idxs.simd_lt(Simd::splat(slice.len()));
+        let enable: Mask<usize, N> = enable & idxs.simd_lt(Simd::splat(slice.len()));
         // Safety: We have masked-off out-of-bounds indices.
         unsafe { Self::gather_select_unchecked(slice, enable, idxs, or) }
     }
@@ -580,7 +568,7 @@ where
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub unsafe fn gather_select_unchecked(
         slice: &[T],
-        enable: Mask<isize, N>,
+        enable: Mask<usize, N>,
         idxs: Simd<usize, N>,
         or: Self,
     ) -> Self {
@@ -588,7 +576,7 @@ where
         // Ferris forgive me, I have done pointer arithmetic here.
         let ptrs = base_ptr.wrapping_add(idxs);
         // Safety: The caller is responsible for determining the indices are okay to read
-        unsafe { Self::gather_select_ptr(ptrs, enable, or) }
+        unsafe { Self::gather_select_ptr(ptrs, enable.cast::<*const T>(), or) }
     }
 
     /// Reads elementwise from pointers into a SIMD vector.
@@ -648,7 +636,7 @@ where
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub unsafe fn gather_select_ptr(
         source: Simd<*const T, N>,
-        enable: Mask<isize, N>,
+        enable: Mask<*const T, N>,
         or: Self,
     ) -> Self {
         // Safety: The caller is responsible for upholding all invariants
@@ -674,7 +662,7 @@ where
     /// assert_eq!(arr, [0, -4, -3, 0]);
     /// ```
     #[inline]
-    pub fn store_select(self, slice: &mut [T], mut enable: Mask<<T as SimdElement>::Mask, N>) {
+    pub fn store_select(self, slice: &mut [T], mut enable: Mask<T, N>) {
         enable &= mask_up_to(slice.len());
         // SAFETY: We performed the bounds check by updating the mask. &[T] is properly aligned to
         // the element.
@@ -702,11 +690,7 @@ where
     /// assert_eq!(arr, [0, -4, -3, -2]);
     /// ```
     #[inline]
-    pub unsafe fn store_select_unchecked(
-        self,
-        slice: &mut [T],
-        enable: Mask<<T as SimdElement>::Mask, N>,
-    ) {
+    pub unsafe fn store_select_unchecked(self, slice: &mut [T], enable: Mask<T, N>) {
         let ptr = slice.as_mut_ptr();
         // SAFETY: The safety of writing elements in `slice` is ensured by the caller.
         unsafe { self.store_select_ptr(ptr, enable) }
@@ -721,7 +705,7 @@ where
     /// Memory addresses for element are calculated [`pointer::wrapping_offset`] and
     /// each enabled element must satisfy the same conditions as [`core::ptr::write`].
     #[inline]
-    pub unsafe fn store_select_ptr(self, ptr: *mut T, enable: Mask<<T as SimdElement>::Mask, N>) {
+    pub unsafe fn store_select_ptr(self, ptr: *mut T, enable: Mask<T, N>) {
         // SAFETY: The safety of writing elements through `ptr` is ensured by the caller.
         unsafe { core::intrinsics::simd::simd_masked_store(enable.to_simd(), ptr, self) }
     }
@@ -768,8 +752,8 @@ where
     /// assert_eq!(vec, vec![-41, 11, 12, 82, 14, 15, 16, 17, 18]);
     /// ```
     #[inline]
-    pub fn scatter_select(self, slice: &mut [T], enable: Mask<isize, N>, idxs: Simd<usize, N>) {
-        let enable: Mask<isize, N> = enable & idxs.simd_lt(Simd::splat(slice.len()));
+    pub fn scatter_select(self, slice: &mut [T], enable: Mask<usize, N>, idxs: Simd<usize, N>) {
+        let enable: Mask<usize, N> = enable & idxs.simd_lt(Simd::splat(slice.len()));
         // Safety: We have masked-off out-of-bounds indices.
         unsafe { self.scatter_select_unchecked(slice, enable, idxs) }
     }
@@ -808,7 +792,7 @@ where
     pub unsafe fn scatter_select_unchecked(
         self,
         slice: &mut [T],
-        enable: Mask<isize, N>,
+        enable: Mask<usize, N>,
         idxs: Simd<usize, N>,
     ) {
         // Safety: This block works with *mut T derived from &mut 'a [T],
@@ -827,7 +811,7 @@ where
             // Ferris forgive me, I have done pointer arithmetic here.
             let ptrs = base_ptr.wrapping_add(idxs);
             // The ptrs have been bounds-masked to prevent memory-unsafe writes insha'allah
-            self.scatter_select_ptr(ptrs, enable);
+            self.scatter_select_ptr(ptrs, enable.cast::<*mut T>());
             // Cleared ☢️ *mut T Zone
         }
     }
@@ -880,7 +864,7 @@ where
     /// ```
     #[inline]
     #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
-    pub unsafe fn scatter_select_ptr(self, dest: Simd<*mut T, N>, enable: Mask<isize, N>) {
+    pub unsafe fn scatter_select_ptr(self, dest: Simd<*mut T, N>, enable: Mask<*mut T, N>) {
         // Safety: The caller is responsible for upholding all invariants
         unsafe { core::intrinsics::simd::simd_scatter(self, dest, enable.to_simd()) }
     }
@@ -926,7 +910,7 @@ where
         let mask = unsafe {
             let tfvec: Simd<<T as SimdElement>::Mask, N> =
                 core::intrinsics::simd::simd_eq(*self, *other);
-            Mask::from_simd_unchecked(tfvec)
+            Mask::<T, N>::from_simd_unchecked(tfvec)
         };
 
         // Two vectors are equal if all elements are equal when compared elementwise
@@ -940,7 +924,7 @@ where
         let mask = unsafe {
             let tfvec: Simd<<T as SimdElement>::Mask, N> =
                 core::intrinsics::simd::simd_ne(*self, *other);
-            Mask::from_simd_unchecked(tfvec)
+            Mask::<T, N>::from_simd_unchecked(tfvec)
         };
 
         // Two vectors are non-equal if any elements are non-equal when compared elementwise
@@ -1233,20 +1217,27 @@ where
 fn mask_up_to<M, const N: usize>(len: usize) -> Mask<M, N>
 where
     LaneCount<N>: SupportedLaneCount,
-    M: MaskElement,
+    M: SimdElement,
 {
     let index = lane_indices::<N>();
-    let max_value: u64 = M::max_unsigned();
-    macro_rules! case {
-        ($ty:ty) => {
-            if N < <$ty>::MAX as usize && max_value as $ty as u64 == max_value {
-                return index.cast().simd_lt(Simd::splat(len.min(N) as $ty)).cast();
-            }
-        };
+    // Choose the comparison width based on the mask element size of M
+    match core::mem::size_of::<M::Mask>() {
+        1 => {
+            let idx: Simd<u8, N> = index.cast();
+            idx.simd_lt(Simd::splat(len.min(N) as u8)).cast()
+        }
+        2 => {
+            let idx: Simd<u16, N> = index.cast();
+            idx.simd_lt(Simd::splat(len.min(N) as u16)).cast()
+        }
+        4 => {
+            let idx: Simd<u32, N> = index.cast();
+            idx.simd_lt(Simd::splat(len.min(N) as u32)).cast()
+        }
+        8 => {
+            let idx: Simd<u64, N> = index.cast();
+            idx.simd_lt(Simd::splat(len.min(N) as u64)).cast()
+        }
+        _ => index.simd_lt(Simd::splat(len)).cast(),
     }
-    case!(u8);
-    case!(u16);
-    case!(u32);
-    case!(u64);
-    index.simd_lt(Simd::splat(len)).cast()
 }

--- a/crates/core_simd/tests/masks.rs
+++ b/crates/core_simd/tests/masks.rs
@@ -113,7 +113,7 @@ macro_rules! test_mask_api {
 
             #[test]
             fn cast() {
-                fn cast_impl<T: core_simd::simd::MaskElement>()
+                fn cast_impl<T: core_simd::simd::SimdElement>()
                 where
                     Mask<$type, 8>: Into<Mask<T, 8>>,
                 {


### PR DESCRIPTION
#322 redux

Arguments for this change:
* Integer elements impose a very specific view of masks (AVX512, SVE, RVV, etc use bitmasks). `Mask<i32, 4>` over `Simd<f32, 4>` only maps to one type of implementation. `Mask<f32, 4>` just means "a mask over f32s"
* Some API surface is reduced: `T::Mask` disappears from everywhere except `Mask::to_simd`/`Mask::from_simd`. `MaskElement` is removed from the public API.

This comment from @thomcc summarizes the arguments against this change in the previous PR: https://github.com/rust-lang/portable-simd/pull/322#issuecomment-1464710468
* I think the first comment regarding API friction is no longer relevant, as this PR includes `From` implementations for all masks. Additionally, `Select` was changed in #482 to allow any mask to select any vector as long as it has the same number of elements. Some code will require slightly more calls `into()`/`cast()` in some situations but otherwise there should be minimal overhead.
* Regarding the second comment about complicated types and projections, this PR doesn't really make this worse anywhere, and probably makes it better in a lot of places, e.g. you can make a function generic over `T: SimdElement` and that will also be your mask type.
