### PR TITLE
float reduce_max/min: fix SNaN treatment

### DIFF
--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -430,14 +430,14 @@ macro_rules! impl_trait {
 
             #[inline]
             fn reduce_max(self) -> Self::Scalar {
-                // Safety: `self` is a float vector
-                unsafe { core::intrinsics::simd::simd_reduce_max(self) }
+                // LLVM has no intrinsic we can use here
+                // (https://github.com/llvm/llvm-project/issues/185827).
+                self.as_array().iter().copied().fold(Self::Scalar::NAN, Self::Scalar::max)
             }
 
             #[inline]
             fn reduce_min(self) -> Self::Scalar {
-                // Safety: `self` is a float vector
-                unsafe { core::intrinsics::simd::simd_reduce_min(self) }
+                self.as_array().iter().copied().fold(Self::Scalar::NAN, Self::Scalar::min)
             }
         }
         )*


### PR DESCRIPTION
I assume the reduce operations are meant to match the semantics of the scalar operations -- that's in fact what the tests are checking for. However, it is currently not the case: when an input is SNaN, the LLVM intrinsic that we use for `simd_reduce_max` on floats may entirely short-circuit the computation and make the entire result a NaN. In contrast, the operation used as [reference for the tests](https://github.com/rust-lang/portable-simd/blob/1982d871475ffb8c2c160a96916a76fdcb6eb11c/crates/core_simd/tests/ops_macros.rs#L706-L728) will skip all SNaN and only consider actual numeric inputs.

LLVM currently has no vector-reduce operation that skips SNaN (https://github.com/llvm/llvm-project/issues/185827), so the best we can do at the moment is stop using the intrinsic.

Is there a good place to add a test specifically for SNaN inputs?

Also see https://github.com/rust-lang/rust/issues/153395.