### PR TITLE
sync to `nightly-2026-04-11`

### DIFF
--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -385,13 +385,13 @@ macro_rules! impl_trait {
             #[inline]
             fn simd_min(self, other: Self) -> Self {
                 // Safety: `self` and `other` are float vectors
-                unsafe { core::intrinsics::simd::simd_fmin(self, other) }
+                unsafe { core::intrinsics::simd::simd_minimum_number_nsz(self, other) }
             }
 
             #[inline]
             fn simd_max(self, other: Self) -> Self {
                 // Safety: `self` and `other` are floating point vectors
-                unsafe { core::intrinsics::simd::simd_fmax(self, other) }
+                unsafe { core::intrinsics::simd::simd_maximum_number_nsz(self, other) }
             }
 
             #[inline]

--- a/crates/std_float/tests/float.rs
+++ b/crates/std_float/tests/float.rs
@@ -33,23 +33,6 @@ macro_rules! unary_approx_test {
     }
 }
 
-macro_rules! binary_approx_test {
-    { $scalar:tt, $($func:tt),+ } => {
-        test_helpers::test_lanes! {
-            $(
-            fn $func<const LANES: usize>() {
-                test_helpers::test_binary_elementwise_approx(
-                    &core_simd::simd::Simd::<$scalar, LANES>::$func,
-                    &$scalar::$func,
-                    &|_, _| true,
-                    16,
-                )
-            }
-            )*
-        }
-    }
-}
-
 macro_rules! ternary_test {
     { $scalar:tt, $($func:tt),+ } => {
         test_helpers::test_lanes! {
@@ -76,7 +59,19 @@ macro_rules! impl_tests {
 
             // https://github.com/rust-lang/miri/issues/3555
             unary_approx_test! { $scalar, sin, cos, exp, exp2, ln, log2, log10 }
-            binary_approx_test! { $scalar, log }
+
+            // The implementation of log is a.ln() / b.ln(), so there are 2 inexact operations,
+            // hence a larger ulps is needed.
+            test_helpers::test_lanes! {
+                fn log<const LANES: usize>() {
+                    test_helpers::test_binary_elementwise_approx(
+                        &core_simd::simd::Simd::<$scalar, LANES>::log,
+                        &$scalar::log,
+                        &|_, _| true,
+                        32,
+                    )
+                }
+            }
 
             test_helpers::test_lanes! {
                 fn fract<const LANES: usize>() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-03-18"
+channel = "nightly-2026-04-11"
 components = ["rustfmt", "clippy", "miri", "rust-src"]


### PR DESCRIPTION
Not sure the sync quite worked with that extra merge commit? maybe it's fine though.

I'd like to actually sync the other way, but that'll only work when we use an up-to-date nightly here.

I could also open this as my own commit with the 3 lines changed to what they should be, I'm not sure how that synchronizes.