### PR TITLE
run `f16` float tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,15 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,7 +379,6 @@ dependencies = [
 name = "test_helpers"
 version = "0.1.0"
 dependencies = [
- "float-cmp",
  "proptest",
 ]
 

--- a/crates/std_float/tests/float.rs
+++ b/crates/std_float/tests/float.rs
@@ -1,4 +1,5 @@
 #![feature(portable_simd)]
+#![feature(f16)]
 
 macro_rules! unary_test {
     { $scalar:tt, $($func:tt),+ } => {
@@ -91,5 +92,6 @@ macro_rules! impl_tests {
     }
 }
 
+impl_tests! { f16 }
 impl_tests! { f32 }
 impl_tests! { f64 }

--- a/crates/test_helpers/Cargo.toml
+++ b/crates/test_helpers/Cargo.toml
@@ -6,4 +6,3 @@ publish = false
 
 [dependencies]
 proptest = { workspace = true, features = ["alloc", "std"] }
-float-cmp = "0.10"

--- a/crates/test_helpers/src/approxeq.rs
+++ b/crates/test_helpers/src/approxeq.rs
@@ -1,7 +1,5 @@
 //! Compare numeric types approximately.
 
-use float_cmp::Ulps;
-
 pub trait ApproxEq {
     fn approxeq(&self, other: &Self, _ulps: i64) -> bool;
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result;
@@ -43,7 +41,14 @@ macro_rules! impl_float_approxeq {
                 if self.is_nan() && other.is_nan() {
                     true
                 } else {
-                    (self.ulps(other) as i64).abs() <= ulps
+                    let allowed_ulp_diff = ulps;
+
+                    // Approximate the ULP by taking half the distance between the number one place "up"
+                    // and the number one place "down".
+                    let ulp = (other.next_up() - other.next_down()) / 2.0;
+                    let ulp_diff = ((self - other) / ulp).abs().round() as i64;
+
+                    ulp_diff <= allowed_ulp_diff
                 }
             }
 
@@ -55,7 +60,7 @@ macro_rules! impl_float_approxeq {
     };
 }
 
-impl_float_approxeq! { f32, f64 }
+impl_float_approxeq! { f16, f32, f64 }
 
 impl<T: ApproxEq, const N: usize> ApproxEq for [T; N] {
     fn approxeq(&self, other: &Self, ulps: i64) -> bool {


### PR DESCRIPTION
the `float-cmp` and `num-traits` libraries don't (yet) support `f16`, and likely won't do so before the type is stabilized.

Luckily it turns out that we only really need one function from them for checking whether two floats are "close enough". Miri already has this logic, which I've adapted here.

https://github.com/rust-lang/miri/blob/871d3d06c549cb554dec9a3a7c37cdd723254d06/tests/pass/float.rs#L40-L51

With that we can actually drop the dependency on `float-cmp`, which is neat too.
