### PR TITLE
disable `f16` tests for the cranelift backend

### DIFF
--- a/crates/core_simd/Cargo.toml
+++ b/crates/core_simd/Cargo.toml
@@ -31,3 +31,11 @@ path = "../test_helpers"
 
 [dev-dependencies]
 std_float = { path = "../std_float/", features = ["as_crate"] }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    # Internal features aren't marked known config by default, we use these to
+    # gate tests.
+    'cfg(target_has_reliable_f16_math)',
+]

--- a/crates/core_simd/tests/f16_ops.rs
+++ b/crates/core_simd/tests/f16_ops.rs
@@ -1,5 +1,7 @@
 #![feature(portable_simd)]
 #![feature(f16)]
+#![expect(internal_features)]
+#![feature(cfg_target_has_reliable_f16_f128)]
 
 #[macro_use]
 mod ops_macros;
@@ -7,4 +9,5 @@ mod ops_macros;
 // FIXME: some f16 operations cause rustc to hang on wasm simd
 // https://github.com/llvm/llvm-project/issues/189251
 #[cfg(not(all(target_arch = "wasm32", target_feature = "simd128")))]
+#[cfg(target_has_reliable_f16_math)]
 impl_float_tests! { f16, i16 }


### PR DESCRIPTION
fixes rust-lang/portable-simd#519 

@bjorn3 does this look like it would work?