### PR TITLE
Optimize `swizzle_dyn` for AArch64 with N > 16

### DIFF
--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -14,11 +14,6 @@ impl<const N: usize> Simd<u8, N> {
     pub fn swizzle_dyn(self, idxs: Simd<u8, N>) -> Self {
         #![allow(unused_imports, unused_unsafe)]
         #[cfg(all(
-            any(target_arch = "aarch64", target_arch = "arm64ec"),
-            target_endian = "little"
-        ))]
-        use core::arch::aarch64::{uint8x8_t, vqtbl1q_u8, vtbl1_u8};
-        #[cfg(all(
             target_arch = "arm",
             target_feature = "v7",
             target_feature = "neon",
@@ -37,25 +32,15 @@ impl<const N: usize> Simd<u8, N> {
         unsafe {
             match N {
                 #[cfg(all(
-                    any(
-                        target_arch = "aarch64",
-                        target_arch = "arm64ec",
-                        all(target_arch = "arm", target_feature = "v7")
-                    ),
-                    target_feature = "neon",
-                    target_endian = "little"
-                ))]
-                8 => transize(vtbl1_u8, self, idxs),
-                #[cfg(target_feature = "ssse3")]
-                16 => transize(x86::_mm_shuffle_epi8, self, zeroing_idxs(idxs)),
-                #[cfg(target_feature = "simd128")]
-                16 => transize(wasm::i8x16_swizzle, self, idxs),
-                #[cfg(all(
                     any(target_arch = "aarch64", target_arch = "arm64ec"),
                     target_feature = "neon",
                     target_endian = "little"
                 ))]
-                16 => transize(vqtbl1q_u8, self, idxs),
+                8 | 16 | 24 | 32 | 48 | 64 => aarch64_swizzle(self, idxs),
+                #[cfg(target_feature = "ssse3")]
+                16 => transize(x86::_mm_shuffle_epi8, self, zeroing_idxs(idxs)),
+                #[cfg(target_feature = "simd128")]
+                16 => transize(wasm::i8x16_swizzle, self, idxs),
                 #[cfg(all(
                     target_arch = "arm",
                     target_feature = "v7",
@@ -123,6 +108,73 @@ unsafe fn armv7_neon_swizzle_u8x16(bytes: Simd<u8, 16>, idxs: Simd<u8, 16>) -> S
         let lo = vtbl2_u8(bytes, vget_low_u8(idxs.into()));
         let hi = vtbl2_u8(bytes, vget_high_u8(idxs.into()));
         vcombine_u8(lo, hi).into()
+    }
+}
+
+/// AArch64 NEON supports swizzling 8, 16, 24, 32, 48 or 64 by stacking multiple TBL instructions.
+///
+/// # Safety
+/// This requires AArch64 NEON to work
+#[cfg(all(
+    any(target_arch = "aarch64", target_arch = "arm64ec"),
+    target_feature = "neon",
+    target_endian = "little"
+))]
+unsafe fn aarch64_swizzle<const N: usize>(bytes: Simd<u8, N>, idxs: Simd<u8, N>) -> Simd<u8, N> {
+    use core::arch::aarch64::*;
+    use core::mem::transmute_copy;
+
+    // SAFETY: Caller promised AArch64 NEON support
+    unsafe {
+        match N {
+            8 => transmute_copy(&vtbl1_u8(transmute_copy(&bytes), transmute_copy(&idxs))),
+            16 => transmute_copy(&vqtbl1q_u8(transmute_copy(&bytes), transmute_copy(&idxs))),
+            24 => {
+                let bytes: uint8x8x3_t = transmute_copy(&bytes);
+                let idxs: uint8x8x3_t = transmute_copy(&idxs);
+
+                let ret0 = vtbl3_u8(bytes, idxs.0);
+                let ret1 = vtbl3_u8(bytes, idxs.1);
+                let ret2 = vtbl3_u8(bytes, idxs.2);
+
+                let ret = uint8x8x3_t(ret0, ret1, ret2);
+                transmute_copy(&ret)
+            }
+            32 => {
+                let bytes: uint8x16x2_t = transmute_copy(&bytes);
+                let idxs: uint8x16x2_t = transmute_copy(&idxs);
+
+                let ret0 = vqtbl2q_u8(bytes, idxs.0);
+                let ret1 = vqtbl2q_u8(bytes, idxs.1);
+
+                let ret = uint8x16x2_t(ret0, ret1);
+                transmute_copy(&ret)
+            }
+            48 => {
+                let bytes: uint8x16x3_t = transmute_copy(&bytes);
+                let idxs: uint8x16x3_t = transmute_copy(&idxs);
+
+                let ret0 = vqtbl3q_u8(bytes, idxs.0);
+                let ret1 = vqtbl3q_u8(bytes, idxs.1);
+                let ret2 = vqtbl3q_u8(bytes, idxs.2);
+
+                let ret = uint8x16x3_t(ret0, ret1, ret2);
+                transmute_copy(&ret)
+            }
+            64 => {
+                let bytes: uint8x16x4_t = transmute_copy(&bytes);
+                let idxs: uint8x16x4_t = transmute_copy(&idxs);
+
+                let ret0 = vqtbl4q_u8(bytes, idxs.0);
+                let ret1 = vqtbl4q_u8(bytes, idxs.1);
+                let ret2 = vqtbl4q_u8(bytes, idxs.2);
+                let ret3 = vqtbl4q_u8(bytes, idxs.3);
+
+                let ret = uint8x16x4_t(ret0, ret1, ret2, ret3);
+                transmute_copy(&ret)
+            }
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/crates/test_helpers/src/lib.rs
+++ b/crates/test_helpers/src/lib.rs
@@ -678,7 +678,7 @@ macro_rules! test_lanes {
                     //lanes_45 45;
                     //lanes_46 46;
                     lanes_47 47;
-                    //lanes_48 48;
+                    lanes_48 48;
                     //lanes_49 49;
                     //lanes_50 50;
                     //lanes_51 51;


### PR DESCRIPTION
We can do swizzles for 24, 32, 48 and 64 byte vectors by stacking multiple TBL instructions.

See https://godbolt.org/z/PE95nrqjj for a comparison of the generated assembly.

I would do the same optimization for 32-bit Arm but I can't get at the intrinsics for some reason: https://godbolt.org/z/54jqTEeeW
