### PR TITLE
Use `impl` restrictions over hand-sealed traits

### DIFF
--- a/crates/core_simd/src/cast.rs
+++ b/crates/core_simd/src/cast.rs
@@ -1,54 +1,35 @@
 use crate::simd::SimdElement;
 
-mod sealed {
-    /// Cast vector elements to other types.
-    ///
-    /// # Safety
-    /// Implementing this trait asserts that the type is a valid vector element for the `simd_cast`
-    /// or `simd_as` intrinsics.
-    pub unsafe trait Sealed {}
-}
-use sealed::Sealed;
-
 /// Supporting trait for `Simd::cast`.  Typically doesn't need to be used directly.
-pub trait SimdCast: Sealed + SimdElement {}
+///
+/// # Safety
+/// Implementing this trait asserts that the type is a valid vector element for the `simd_cast` or
+/// `simd_as` intrinsics.
+pub impl(self) unsafe trait SimdCast: SimdElement {}
 
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for i8 {}
-impl SimdCast for i8 {}
+unsafe impl SimdCast for i8 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for i16 {}
-impl SimdCast for i16 {}
+unsafe impl SimdCast for i16 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for i32 {}
-impl SimdCast for i32 {}
+unsafe impl SimdCast for i32 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for i64 {}
-impl SimdCast for i64 {}
+unsafe impl SimdCast for i64 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for isize {}
-impl SimdCast for isize {}
+unsafe impl SimdCast for isize {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for u8 {}
-impl SimdCast for u8 {}
+unsafe impl SimdCast for u8 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for u16 {}
-impl SimdCast for u16 {}
+unsafe impl SimdCast for u16 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for u32 {}
-impl SimdCast for u32 {}
+unsafe impl SimdCast for u32 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for u64 {}
-impl SimdCast for u64 {}
+unsafe impl SimdCast for u64 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for usize {}
-impl SimdCast for usize {}
+unsafe impl SimdCast for usize {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for f16 {}
-impl SimdCast for f16 {}
+unsafe impl SimdCast for f16 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for f32 {}
-impl SimdCast for f32 {}
+unsafe impl SimdCast for f32 {}
 // Safety: primitive number types can be cast to other primitive number types
-unsafe impl Sealed for f64 {}
-impl SimdCast for f64 {}
+unsafe impl SimdCast for f64 {}

--- a/crates/core_simd/src/lib.rs
+++ b/crates/core_simd/src/lib.rs
@@ -4,6 +4,7 @@
     f16,
     core_intrinsics,
     decl_macro,
+    impl_restriction,
     repr_simd,
     staged_api,
     prelude_import,

--- a/crates/core_simd/src/masks.rs
+++ b/crates/core_simd/src/masks.rs
@@ -29,7 +29,7 @@ macro_rules! impl_fix_endianness {
 
 impl_fix_endianness! { u8, u16, u32, u64 }
 
-mod sealed {
+mod private_methods {
     use super::*;
 
     /// Not only does this seal the `MaskElement` trait, but these functions prevent other traits
@@ -38,7 +38,7 @@ mod sealed {
     /// For example, `eq` could be provided by requiring `MaskElement: PartialEq`, but that would
     /// prevent us from ever removing that bound, or from implementing `MaskElement` on
     /// non-`PartialEq` types in the future.
-    pub trait Sealed {
+    pub impl(super) trait PrivateMethods {
         fn valid<const N: usize>(values: Simd<Self, N>) -> bool
         where
             Self: SimdElement;
@@ -55,17 +55,20 @@ mod sealed {
         const FALSE: Self;
     }
 }
-use sealed::Sealed;
+use private_methods::PrivateMethods;
 
 /// Marker trait for types that may be used as SIMD mask elements.
 ///
 /// # Safety
 /// Type must be a signed integer.
-pub unsafe trait MaskElement: SimdElement<Mask = Self> + SimdCast + Sealed {}
+pub impl(self) unsafe trait MaskElement:
+    SimdElement<Mask = Self> + SimdCast + PrivateMethods
+{
+}
 
 macro_rules! impl_element {
     { $ty:ty, $unsigned:ty } => {
-        impl Sealed for $ty {
+        impl PrivateMethods for $ty {
             #[inline]
             fn valid<const N: usize>(value: Simd<Self, N>) -> bool
             {
@@ -196,7 +199,7 @@ where
     pub unsafe fn from_simd_unchecked(value: Simd<T, N>) -> Self {
         // Safety: the caller must confirm this invariant
         unsafe {
-            core::intrinsics::assume(<T as Sealed>::valid(value));
+            core::intrinsics::assume(<T as PrivateMethods>::valid(value));
         }
         Self(value)
     }

--- a/crates/core_simd/src/simd/num.rs
+++ b/crates/core_simd/src/simd/num.rs
@@ -4,10 +4,6 @@ mod float;
 mod int;
 mod uint;
 
-mod sealed {
-    pub trait Sealed {}
-}
-
 pub use float::*;
 pub use int::*;
 pub use uint::*;

--- a/crates/core_simd/src/simd/num/float.rs
+++ b/crates/core_simd/src/simd/num/float.rs
@@ -1,11 +1,10 @@
-use super::sealed::Sealed;
 use crate::simd::{
     Mask, Select, Simd, SimdCast, SimdElement,
     cmp::{SimdPartialEq, SimdPartialOrd},
 };
 
 /// Operations on SIMD vectors of floats.
-pub trait SimdFloat: Copy + Sealed {
+pub impl(self) trait SimdFloat: Copy {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 
@@ -240,8 +239,6 @@ pub trait SimdFloat: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ty { bits: $bits_ty:ty, mask: $mask_ty:ty }),* } => {
         $(
-        impl<const N: usize> Sealed for Simd<$ty, N> {}
-
         impl<const N: usize> SimdFloat for Simd<$ty, N>
         {
             type Mask = Mask<<$mask_ty as SimdElement>::Mask, N>;

--- a/crates/core_simd/src/simd/num/int.rs
+++ b/crates/core_simd/src/simd/num/int.rs
@@ -1,10 +1,9 @@
-use super::sealed::Sealed;
 use crate::simd::{
     Mask, Select, Simd, SimdCast, SimdElement, cmp::SimdOrd, cmp::SimdPartialOrd, num::SimdUint,
 };
 
 /// Operations on SIMD vectors of signed integers.
-pub trait SimdInt: Copy + Sealed {
+pub impl(self) trait SimdInt: Copy {
     /// Mask type used for manipulating this SIMD vector type.
     type Mask;
 
@@ -241,8 +240,6 @@ pub trait SimdInt: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ident ($unsigned:ident)),* } => {
         $(
-        impl<const N: usize> Sealed for Simd<$ty, N> {}
-
         impl<const N: usize> SimdInt for Simd<$ty, N> {
             type Mask = Mask<<$ty as SimdElement>::Mask, N>;
             type Scalar = $ty;

--- a/crates/core_simd/src/simd/num/uint.rs
+++ b/crates/core_simd/src/simd/num/uint.rs
@@ -1,8 +1,7 @@
-use super::sealed::Sealed;
 use crate::simd::{Simd, SimdCast, SimdElement, cmp::SimdOrd};
 
 /// Operations on SIMD vectors of unsigned integers.
-pub trait SimdUint: Copy + Sealed {
+pub impl(self) trait SimdUint: Copy {
     /// Scalar type contained by this SIMD vector type.
     type Scalar;
 
@@ -124,8 +123,6 @@ pub trait SimdUint: Copy + Sealed {
 macro_rules! impl_trait {
     { $($ty:ident ($signed:ident)),* } => {
         $(
-        impl<const N: usize> Sealed for Simd<$ty, N> {}
-
         impl<const N: usize> SimdUint for Simd<$ty, N>
         {
             type Scalar = $ty;

--- a/crates/core_simd/src/simd/ptr.rs
+++ b/crates/core_simd/src/simd/ptr.rs
@@ -3,10 +3,6 @@
 mod const_ptr;
 mod mut_ptr;
 
-mod sealed {
-    pub trait Sealed {}
-}
-
 pub use const_ptr::*;
 pub use mut_ptr::*;
 

--- a/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -1,8 +1,7 @@
-use super::sealed::Sealed;
 use crate::simd::{Mask, Simd, cmp::SimdPartialEq, num::SimdUint};
 
 /// Operations on SIMD vectors of constant pointers.
-pub trait SimdConstPtr: Copy + Sealed {
+pub impl(self) trait SimdConstPtr: Copy {
     /// Vector of `usize` with the same number of elements.
     type Usize;
 
@@ -64,8 +63,6 @@ pub trait SimdConstPtr: Copy + Sealed {
     /// Equivalent to calling [`pointer::wrapping_sub`] on each element.
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
-
-impl<T, const N: usize> Sealed for Simd<*const T, N> {}
 
 impl<T, const N: usize> SimdConstPtr for Simd<*const T, N> {
     type Usize = Simd<usize, N>;

--- a/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -1,8 +1,7 @@
-use super::sealed::Sealed;
 use crate::simd::{Mask, Simd, cmp::SimdPartialEq, num::SimdUint};
 
 /// Operations on SIMD vectors of mutable pointers.
-pub trait SimdMutPtr: Copy + Sealed {
+pub impl(self) trait SimdMutPtr: Copy {
     /// Vector of `usize` with the same number of elements.
     type Usize;
 
@@ -64,8 +63,6 @@ pub trait SimdMutPtr: Copy + Sealed {
     /// Equivalent to calling [`pointer::wrapping_sub`] on each element.
     fn wrapping_sub(self, count: Self::Usize) -> Self;
 }
-
-impl<T, const N: usize> Sealed for Simd<*mut T, N> {}
 
 impl<T, const N: usize> SimdMutPtr for Simd<*mut T, N> {
     type Usize = Simd<usize, N>;

--- a/crates/core_simd/src/to_bytes.rs
+++ b/crates/core_simd/src/to_bytes.rs
@@ -1,17 +1,10 @@
 use crate::simd::{
-    Simd, SimdElement,
+    Simd,
     num::{SimdFloat, SimdInt, SimdUint},
 };
 
-mod sealed {
-    use super::*;
-    pub trait Sealed {}
-    impl<T: SimdElement, const N: usize> Sealed for Simd<T, N> {}
-}
-use sealed::Sealed;
-
 /// Converts SIMD vectors to vectors of bytes
-pub trait ToBytes: Sealed {
+pub impl(self) trait ToBytes {
     /// This type, reinterpreted as bytes.
     type Bytes: Copy
         + Unpin

--- a/crates/core_simd/src/vector.rs
+++ b/crates/core_simd/src/vector.rs
@@ -1058,11 +1058,6 @@ where
     }
 }
 
-mod sealed {
-    pub trait Sealed {}
-}
-use sealed::Sealed;
-
 /// Marker trait for types that may be used as SIMD vector elements.
 ///
 /// # Safety
@@ -1071,103 +1066,75 @@ use sealed::Sealed;
 /// Strictly, it is valid to impl if the vector will not be miscompiled.
 /// Practically, it is user-unfriendly to impl it if the vector won't compile,
 /// even when no soundness guarantees are broken by allowing the user to try.
-pub unsafe trait SimdElement: Sealed + Copy {
+pub impl(self) unsafe trait SimdElement: Copy {
     /// The mask element type corresponding to this element type.
     type Mask: MaskElement;
 }
-
-impl Sealed for u8 {}
 
 // Safety: u8 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for u8 {
     type Mask = i8;
 }
 
-impl Sealed for u16 {}
-
 // Safety: u16 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for u16 {
     type Mask = i16;
 }
-
-impl Sealed for u32 {}
 
 // Safety: u32 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for u32 {
     type Mask = i32;
 }
 
-impl Sealed for u64 {}
-
 // Safety: u64 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for u64 {
     type Mask = i64;
 }
-
-impl Sealed for usize {}
 
 // Safety: usize is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for usize {
     type Mask = isize;
 }
 
-impl Sealed for i8 {}
-
 // Safety: i8 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for i8 {
     type Mask = i8;
 }
-
-impl Sealed for i16 {}
 
 // Safety: i16 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for i16 {
     type Mask = i16;
 }
 
-impl Sealed for i32 {}
-
 // Safety: i32 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for i32 {
     type Mask = i32;
 }
-
-impl Sealed for i64 {}
 
 // Safety: i64 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for i64 {
     type Mask = i64;
 }
 
-impl Sealed for isize {}
-
 // Safety: isize is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for isize {
     type Mask = isize;
 }
-
-impl Sealed for f16 {}
 
 // Safety: f16 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for f16 {
     type Mask = i16;
 }
 
-impl Sealed for f32 {}
-
 // Safety: f32 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for f32 {
     type Mask = i32;
 }
 
-impl Sealed for f64 {}
-
 // Safety: f64 is a valid SIMD element type, and is supported by this API
 unsafe impl SimdElement for f64 {
     type Mask = i64;
 }
-
-impl<T> Sealed for *const T {}
 
 // Safety: (thin) const pointers are valid SIMD element types, and are supported by this API
 //
@@ -1178,8 +1145,6 @@ where
 {
     type Mask = isize;
 }
-
-impl<T> Sealed for *mut T {}
 
 // Safety: (thin) mut pointers are valid SIMD element types, and are supported by this API
 //

--- a/crates/std_float/src/lib.rs
+++ b/crates/std_float/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(impl_restriction)]
 #![cfg_attr(
     feature = "as_crate",
     feature(core_intrinsics),
@@ -13,16 +14,6 @@ use core_simd::simd;
 use core::intrinsics::simd as intrinsics;
 
 use simd::Simd;
-
-#[cfg(feature = "as_crate")]
-mod experimental {
-    pub trait Sealed {}
-}
-
-#[cfg(feature = "as_crate")]
-use experimental as sealed;
-
-use crate::sealed::Sealed;
 
 /// This trait provides a possibly-temporary implementation of float functions
 /// that may, in the absence of hardware support, canonicalize to calling an
@@ -43,7 +34,7 @@ use crate::sealed::Sealed;
 /// when either the compiler or its supporting runtime functions are improved.
 /// For now this trait is available to permit experimentation with SIMD float
 /// operations that may lack hardware support, such as `mul_add`.
-pub trait StdFloat: Sealed + Sized {
+pub impl(self) trait StdFloat: Sized {
     /// Elementwise fused multiply-add. Computes `(self * a) + b` with only one rounding error,
     /// yielding a more accurate result than an unfused multiply-add.
     ///
@@ -169,10 +160,6 @@ pub trait StdFloat: Sealed + Sized {
     #[must_use = "method returns a new vector and does not mutate the original value"]
     fn fract(self) -> Self;
 }
-
-impl<const N: usize> Sealed for Simd<f16, N> {}
-impl<const N: usize> Sealed for Simd<f32, N> {}
-impl<const N: usize> Sealed for Simd<f64, N> {}
 
 impl<const N: usize> StdFloat for Simd<f16, N> {
     #[inline]


### PR DESCRIPTION
As part of rust-lang/rust#105077, I'm beginning to use `#![feature(impl_restriction)]` within the standard library. As portable SIMD is relied upon by the standard library (as a submodule), I thought I would start here.

I have tested the feature myself in a number of situations and have found it works as expected. Feel free to ask any questions you may have.