### PR TITLE
Provide `From` impls for AArch64 ACLE tuple types.

### DIFF
--- a/crates/core_simd/src/vendor/arm.rs
+++ b/crates/core_simd/src/vendor/arm.rs
@@ -7,6 +7,16 @@ use core::arch::arm::*;
 #[cfg(any(target_arch = "aarch64", target_arch = "arm64ec"))]
 use core::arch::aarch64::*;
 
+/// Transmute between `Simd` and ACLE tuple types.
+macro_rules! tuple {
+    ($scalar:ty,$tuple:ty) => {
+        from_transmute! { unsafe Simd<$scalar, { size_of::<$tuple>() / size_of::<$scalar>() }> => $tuple }
+    };
+    ($scalar:ty,$($tuples:ty),*) => {
+        $(tuple! { $scalar, $tuples })*
+    };
+}
+
 #[cfg(all(
     any(
         target_arch = "aarch64",
@@ -17,9 +27,6 @@ use core::arch::aarch64::*;
 ))]
 mod neon {
     use super::*;
-
-    from_transmute! { unsafe f32x2 => float32x2_t }
-    from_transmute! { unsafe f32x4 => float32x4_t }
 
     from_transmute! { unsafe u8x8 => uint8x8_t }
     from_transmute! { unsafe u8x16 => uint8x16_t }
@@ -34,11 +41,15 @@ mod neon {
     from_transmute! { unsafe i16x8 => int16x8_t }
     from_transmute! { unsafe u16x4 => poly16x4_t }
     from_transmute! { unsafe u16x8 => poly16x8_t }
+    from_transmute! { unsafe f16x4 => float16x4_t }
+    from_transmute! { unsafe f16x8 => float16x8_t }
 
     from_transmute! { unsafe u32x2 => uint32x2_t }
     from_transmute! { unsafe u32x4 => uint32x4_t }
     from_transmute! { unsafe i32x2 => int32x2_t }
     from_transmute! { unsafe i32x4 => int32x4_t }
+    from_transmute! { unsafe f32x2 => float32x2_t }
+    from_transmute! { unsafe f32x4 => float32x4_t }
 
     from_transmute! { unsafe Simd<u64, 1> => uint64x1_t }
     from_transmute! { unsafe u64x2 => uint64x2_t }
@@ -46,6 +57,36 @@ mod neon {
     from_transmute! { unsafe i64x2 => int64x2_t }
     from_transmute! { unsafe Simd<u64, 1> => poly64x1_t }
     from_transmute! { unsafe u64x2 => poly64x2_t }
+
+    tuple!(i8, int8x8x2_t, int8x8x3_t, int8x8x4_t);
+    tuple!(i8, int8x16x2_t, int8x16x3_t, int8x16x4_t);
+    tuple!(u8, uint8x8x2_t, uint8x8x3_t, uint8x8x4_t);
+    tuple!(u8, uint8x16x2_t, uint8x16x3_t, uint8x16x4_t);
+    tuple!(u8, poly8x8x2_t, poly8x8x3_t, poly8x8x4_t);
+    tuple!(u8, poly8x16x2_t, poly8x16x3_t, poly8x16x4_t);
+
+    tuple!(i16, int16x4x2_t, int16x4x3_t, int16x4x4_t);
+    tuple!(i16, int16x8x2_t, int16x8x3_t, int16x8x4_t);
+    tuple!(u16, uint16x4x2_t, uint16x4x3_t, uint16x4x4_t);
+    tuple!(u16, uint16x8x2_t, uint16x8x3_t, uint16x8x4_t);
+    tuple!(u16, poly16x4x2_t, poly16x4x3_t, poly16x4x4_t);
+    tuple!(u16, poly16x8x2_t, poly16x8x3_t, poly16x8x4_t);
+    tuple!(f16, float16x4x2_t, float16x4x3_t, float16x4x4_t);
+    tuple!(f16, float16x8x2_t, float16x8x3_t, float16x8x4_t);
+
+    tuple!(i32, int32x2x2_t, int32x2x3_t, int32x2x4_t);
+    tuple!(i32, int32x4x2_t, int32x4x3_t, int32x4x4_t);
+    tuple!(u32, uint32x2x2_t, uint32x2x3_t, uint32x2x4_t);
+    tuple!(u32, uint32x4x2_t, uint32x4x3_t, uint32x4x4_t);
+    tuple!(f32, float32x2x2_t, float32x2x3_t, float32x2x4_t);
+    tuple!(f32, float32x4x2_t, float32x4x3_t, float32x4x4_t);
+
+    tuple!(i64, int64x1x2_t, int64x1x3_t, int64x1x4_t);
+    tuple!(i64, int64x2x2_t, int64x2x3_t, int64x2x4_t);
+    tuple!(u64, uint64x1x2_t, uint64x1x3_t, uint64x1x4_t);
+    tuple!(u64, uint64x2x2_t, uint64x2x3_t, uint64x2x4_t);
+    tuple!(u64, poly64x1x2_t, poly64x1x3_t, poly64x1x4_t);
+    tuple!(u64, poly64x2x2_t, poly64x2x3_t, poly64x2x4_t);
 }
 
 #[cfg(any(
@@ -71,4 +112,7 @@ mod aarch64 {
 
     from_transmute! { unsafe Simd<f64, 1> => float64x1_t }
     from_transmute! { unsafe f64x2 => float64x2_t }
+
+    tuple!(f64, float64x1x2_t, float64x1x3_t, float64x1x4_t);
+    tuple!(f64, float64x2x2_t, float64x2x3_t, float64x2x4_t);
 }


### PR DESCRIPTION
`From` impls were already provided for the normal AArch64 ACLE vector types, but not for the x2,x3,x4 tuples of ACLE vectors. Rectify that.

Also provide impls for vectors of `f16`, as I noticed they were missing.
