### PR TITLE
Optimize swizzle_dyn for double the native vector width

### DIFF
--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -30,19 +30,20 @@ impl<const N: usize> Simd<u8, N> {
         use core::arch::x86_64 as x86;
         // SAFETY: Intrinsics covered by cfg
         unsafe {
+            #[allow(
+                unreachable_patterns,
+                reason = "avoids writing verbose cfg(not), earlier branches take priority"
+            )]
             match N {
+                // Aarch64
                 #[cfg(all(
                     any(target_arch = "aarch64", target_arch = "arm64ec"),
                     target_feature = "neon",
                     target_endian = "little"
                 ))]
                 8 | 16 | 24 | 32 | 48 | 64 => aarch64_swizzle(self, idxs),
-                #[cfg(target_feature = "ssse3")]
-                16 => transize(x86::_mm_shuffle_epi8, self, zeroing_idxs(idxs)),
-                #[cfg(target_feature = "simd128")]
-                16 => transize(wasm::i8x16_swizzle, self, idxs),
-                #[cfg(target_feature = "simd128")]
-                32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
+
+                // 32-bit ARMv7
                 #[cfg(all(
                     target_arch = "arm",
                     target_feature = "v7",
@@ -50,16 +51,26 @@ impl<const N: usize> Simd<u8, N> {
                     target_endian = "little"
                 ))]
                 16 => transize(armv7_neon_swizzle_u8x16, self, idxs),
+
+                // WASM SIMD128
+                #[cfg(target_feature = "simd128")]
+                16 => transize(wasm::i8x16_swizzle, self, idxs),
+                #[cfg(target_feature = "simd128")]
+                32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
+
+                // LoongArch64
                 #[cfg(all(target_arch = "loongarch64", target_feature = "lsx"))]
                 16 => transize(loong64_lsx_swizzle, self, idxs),
-                #[cfg(all(
-                    target_arch = "loongarch64",
-                    target_feature = "lsx",
-                    not(target_feature = "lasx")
-                ))]
+                #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
+                32 => transize(loong64_lasx_swizzle, self, idxs),
+                #[cfg(all(target_arch = "loongarch64", target_feature = "lsx",))]
                 32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
-                #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
-                32 => transize(avx2_pshufb, self, idxs),
+                #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
+                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
+
+                // x86, x86-64
+                #[cfg(target_feature = "ssse3")]
+                16 => transize(x86::_mm_shuffle_epi8, self, zeroing_idxs(idxs)),
                 #[cfg(all(target_feature = "avx512vl", target_feature = "avx512vbmi"))]
                 32 => {
                     // Unlike vpshufb, vpermb doesn't zero out values in the result based on the index high bit
@@ -72,19 +83,11 @@ impl<const N: usize> Simd<u8, N> {
                     };
                     transize(swizzler, self, idxs)
                 }
-                #[cfg(all(
-                    target_feature = "ssse3",
-                    not(target_feature = "avx2"),
-                    not(target_feature = "avx512vbmi")
-                ))]
+                #[cfg(target_feature = "avx2")]
+                32 => transize(avx2_pshufb, self, idxs),
+                #[cfg(target_feature = "ssse3")]
                 32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
-                #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
-                32 => transize(loong64_lasx_swizzle, self, idxs),
                 // Notable absence: avx512bw pshufb shuffle
-                #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
-                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
-                #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
-                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
                 #[cfg(all(target_feature = "avx512vl", target_feature = "avx512vbmi"))]
                 64 => {
                     // Unlike vpshufb, vpermb doesn't zero out values in the result based on the index high bit
@@ -97,6 +100,10 @@ impl<const N: usize> Simd<u8, N> {
                     };
                     transize(swizzler, self, idxs)
                 }
+                #[cfg(target_feature = "avx2")]
+                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
+
+                // scalar fallback
                 _ => {
                     let mut array = [0; N];
                     for (i, k) in idxs.to_array().into_iter().enumerate() {

--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -52,6 +52,12 @@ impl<const N: usize> Simd<u8, N> {
                 16 => transize(armv7_neon_swizzle_u8x16, self, idxs),
                 #[cfg(all(target_arch = "loongarch64", target_feature = "lsx"))]
                 16 => transize(loong64_lsx_swizzle, self, idxs),
+                #[cfg(all(
+                    target_arch = "loongarch64",
+                    target_feature = "lsx",
+                    not(target_feature = "lasx")
+                ))]
+                32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
                 #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
                 32 => transize(avx2_pshufb, self, idxs),
                 #[cfg(all(target_feature = "avx512vl", target_feature = "avx512vbmi"))]
@@ -76,6 +82,8 @@ impl<const N: usize> Simd<u8, N> {
                 32 => transize(loong64_lasx_swizzle, self, idxs),
                 // Notable absence: avx512bw pshufb shuffle
                 #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
+                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
+                #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
                 64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
                 #[cfg(all(target_feature = "avx512vl", target_feature = "avx512vbmi"))]
                 64 => {
@@ -110,7 +118,13 @@ impl<const N: usize> Simd<u8, N> {
         not(target_feature = "avx2"),
         not(target_feature = "avx512vbmi")
     ),
-    all(target_feature = "avx2", not(target_feature = "avx512vbmi"))
+    all(target_feature = "avx2", not(target_feature = "avx512vbmi")),
+    all(
+        target_arch = "loongarch64",
+        target_feature = "lsx",
+        not(target_feature = "lasx")
+    ),
+    all(target_arch = "loongarch64", target_feature = "lasx")
 ))]
 /// Implements an arbitrary shuffle over double the native vector width
 /// using 4 native-width shuffles

--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -111,21 +111,7 @@ impl<const N: usize> Simd<u8, N> {
     }
 }
 
-#[cfg(any(
-    target_feature = "simd128",
-    all(
-        target_feature = "ssse3",
-        not(target_feature = "avx2"),
-        not(target_feature = "avx512vbmi")
-    ),
-    all(target_feature = "avx2", not(target_feature = "avx512vbmi")),
-    all(
-        target_arch = "loongarch64",
-        target_feature = "lsx",
-        not(target_feature = "lasx")
-    ),
-    all(target_arch = "loongarch64", target_feature = "lasx")
-))]
+#[allow(dead_code, reason = "only used on some targets/features")]
 /// Implements an arbitrary shuffle over double the native vector width
 /// using 4 native-width shuffles
 fn swizzle_dyn_split<const N: usize, const HALF: usize>(

--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -63,7 +63,7 @@ impl<const N: usize> Simd<u8, N> {
                 16 => transize(loong64_lsx_swizzle, self, idxs),
                 #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
                 32 => transize(loong64_lasx_swizzle, self, idxs),
-                #[cfg(all(target_arch = "loongarch64", target_feature = "lsx",))]
+                #[cfg(all(target_arch = "loongarch64", target_feature = "lsx"))]
                 32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
                 #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
                 64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),

--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -41,6 +41,8 @@ impl<const N: usize> Simd<u8, N> {
                 16 => transize(x86::_mm_shuffle_epi8, self, zeroing_idxs(idxs)),
                 #[cfg(target_feature = "simd128")]
                 16 => transize(wasm::i8x16_swizzle, self, idxs),
+                #[cfg(target_feature = "simd128")]
+                32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
                 #[cfg(all(
                     target_arch = "arm",
                     target_feature = "v7",
@@ -64,9 +66,17 @@ impl<const N: usize> Simd<u8, N> {
                     };
                     transize(swizzler, self, idxs)
                 }
+                #[cfg(all(
+                    target_feature = "ssse3",
+                    not(target_feature = "avx2"),
+                    not(target_feature = "avx512vbmi")
+                ))]
+                32 => transize(swizzle_dyn_split::<32, 16>, self, idxs),
                 #[cfg(all(target_arch = "loongarch64", target_feature = "lasx"))]
                 32 => transize(loong64_lasx_swizzle, self, idxs),
                 // Notable absence: avx512bw pshufb shuffle
+                #[cfg(all(target_feature = "avx2", not(target_feature = "avx512vbmi")))]
+                64 => transize(swizzle_dyn_split::<64, 32>, self, idxs),
                 #[cfg(all(target_feature = "avx512vl", target_feature = "avx512vbmi"))]
                 64 => {
                     // Unlike vpshufb, vpermb doesn't zero out values in the result based on the index high bit
@@ -91,6 +101,56 @@ impl<const N: usize> Simd<u8, N> {
             }
         }
     }
+}
+
+#[cfg(any(
+    target_feature = "simd128",
+    all(
+        target_feature = "ssse3",
+        not(target_feature = "avx2"),
+        not(target_feature = "avx512vbmi")
+    ),
+    all(target_feature = "avx2", not(target_feature = "avx512vbmi"))
+))]
+/// Implements an arbitrary shuffle over double the native vector width
+/// using 4 native-width shuffles
+fn swizzle_dyn_split<const N: usize, const HALF: usize>(
+    bytes: Simd<u8, N>,
+    idxs: Simd<u8, N>,
+) -> Simd<u8, N> {
+    let table_low = bytes.extract::<0, HALF>();
+    let table_high = bytes.extract::<HALF, HALF>();
+    let idxs_low = idxs.extract::<0, HALF>();
+    let idxs_high = idxs.extract::<HALF, HALF>();
+    let table_high_offset = Simd::<u8, HALF>::splat(HALF as u8);
+
+    let output_low_from_low = table_low.swizzle_dyn(idxs_low);
+    let output_low_from_high = table_high.swizzle_dyn(idxs_low - table_high_offset);
+    let output_low = output_low_from_low | output_low_from_high;
+
+    let output_high_from_low = table_low.swizzle_dyn(idxs_high);
+    let output_high_from_high = table_high.swizzle_dyn(idxs_high - table_high_offset);
+    let output_high = output_high_from_low | output_high_from_high;
+
+    // This is simply a concatenation of two native-sized vectors.
+    // The swizzle does nothing - it maps the elements right back where they already are.
+    // There doesn't seem to be a more direct way to do this as of this writing.
+    // TODO: simplify once a plain `concat` is available.
+    use crate::simd::Swizzle;
+    struct CombineHalves;
+    impl<const N: usize> Swizzle<N> for CombineHalves {
+        const INDEX: [usize; N] = const {
+            let mut index = [0; N];
+            let mut i = 0;
+            while i < N {
+                index[i] = i;
+                i += 1;
+            }
+            index
+        };
+    }
+
+    CombineHalves::concat_swizzle(output_low, output_high)
 }
 
 /// armv7 neon supports swizzling `u8x16` by swizzling two u8x8 blocks


### PR DESCRIPTION
It is quite trivial to decompose a shuffle of double the native vector width into four native-width shuffles. This adds a generic helper that does this, and wires it up to ssse3, AVX2 and WASM.

The strict, portable behavior of always setting out-of-bounds indices to 0 rather than following the hardware behavior actually helps us here: we don't need to separately track which indices were out of bounds for each half of the lookup table, and can combine the results from both halves with a simple bitwise or because each element will be 0 in at least one half of the output.

This is a port/upstreaming of my work on `fearless_simd`: https://github.com/linebender/fearless_simd/pull/276

In fearless_simd I've measured a 4x performance improvement on a [toy base64 implementation](https://github.com/Shnatsel/toy-simd-base64) from this change. I have not benchmarked SSE4.2  in fearless_simd directly but llvm-mca says it's a big improvement.

I have not disassembled or benchmarked this implementation to confirm the performance improvement because CONTRIBUTING.md does not explain how to do that on this crate as opposed to its re-export from std. 

I've run tests on ssse3 and AVX2, which pass.

I have not run tests on WASM, because the tests fail to run in wasmtime with the wasm32-wasip1 target. I hope CI covers that.

~~I have not applied this to LoongArch in this PR, since I have no means of testing it and I doubt CI has either.~~