### PR TITLE
Optimize swizzle_dyn AVX2 implementation

### DIFF
--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -259,35 +259,27 @@ unsafe fn aarch64_swizzle<const N: usize>(bytes: Simd<u8, N>, idxs: Simd<u8, N>)
 #[inline]
 #[allow(clippy::let_and_return)]
 unsafe fn avx2_pshufb(bytes: Simd<u8, 32>, idxs: Simd<u8, 32>) -> Simd<u8, 32> {
-    use crate::simd::{Select, cmp::SimdPartialOrd};
     #[cfg(target_arch = "x86")]
     use core::arch::x86;
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64 as x86;
     use x86::_mm256_permute2x128_si256 as avx2_cross_shuffle;
     use x86::_mm256_shuffle_epi8 as avx2_half_pshufb;
-    let mid = Simd::splat(16u8);
-    let high = mid + mid;
     // SAFETY: Caller promised AVX2
     unsafe {
-        // This is ordering sensitive, and LLVM will order these how you put them.
-        // Most AVX2 impls use ~5 "ports", and only 1 or 2 are capable of permutes.
-        // But the "compose" step will lower to ops that can also use at least 1 other port.
-        // So this tries to break up permutes so composition flows through "open" ports.
-        // Comparative benches should be done on multiple AVX2 CPUs before reordering this
-
-        let hihi = avx2_cross_shuffle::<0x11>(bytes.into(), bytes.into());
-        let hi_shuf = Simd::from(avx2_half_pshufb(
-            hihi,        // duplicate the vector's top half
-            idxs.into(), // so that using only 4 bits of an index still picks bytes 16-31
-        ));
-        // A zero-fill during the compose step gives the "all-Neon-like" OOB-is-0 semantics
-        let compose = idxs.simd_lt(high).select(hi_shuf, Simd::splat(0));
         let lolo = avx2_cross_shuffle::<0x00>(bytes.into(), bytes.into());
-        let lo_shuf = Simd::from(avx2_half_pshufb(lolo, idxs.into()));
-        // Repeat, then pick indices < 16, overwriting indices 0-15 from previous compose step
-        let compose = idxs.simd_lt(mid).select(lo_shuf, compose);
-        compose
+        let hihi = avx2_cross_shuffle::<0x11>(bytes.into(), bytes.into());
+
+        // Adding 0x60 preserves the low nibble and bit 4 for valid
+        // indices 0..=31. Larger indices get their high bit set, so
+        // VPSHUFB supplies the required out-of-bounds zeroing.
+        let control = x86::_mm256_adds_epu8(idxs.into(), x86::_mm256_set1_epi8(0x60));
+
+        // Move index bit 4 into each byte's sign bit for VPBLENDVB.
+        let select_high = x86::_mm256_slli_epi16::<3>(control);
+        let from_low = avx2_half_pshufb(lolo, control);
+        let from_high = avx2_half_pshufb(hihi, control);
+        x86::_mm256_blendv_epi8(from_low, from_high, select_high).into()
     }
 }
 


### PR DESCRIPTION
 llvm-mca shows:

- no change on Haswell and Broadwell
- 20% improvement on Skylake when using the 512-bit decomposition from rust-lang/portable-simd#540, no change otherwise
- 23% improvement on Zen 1, Zen 2 and Tiger Lake
- 7-20% improvement on Zen 3

End-to-end benchmarks on a [toy base64 implementation](https://github.com/Shnatsel/intrepid-base64) using 512-bit shuffles improve by 7% to 13% on my Zen4 workstation, depending on how you count.

<details><summary>Benchmark details</summary>
<p>

```
$ RUSTFLAGS='--cfg disable_dispatch_avx512' cargo bench  --bench codec -- 1048576
    Finished `bench` profile [optimized] target(s) in 0.02s
     Running benches/codec.rs (target/release/deps/codec-0676c1840143d734)
encode/1048576          time:   [103.20 µs 103.31 µs 103.45 µs]
                        thrpt:  [9.4398 GiB/s 9.4524 GiB/s 9.4631 GiB/s]
                 change:
                        time:   [−11.900% −11.804% −11.685%] (p = 0.00 < 0.05)
                        thrpt:  [+13.231% +13.384% +13.507%]
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  12 (12.00%) high mild
  1 (1.00%) high severe

decode/1048576          time:   [163.61 µs 163.63 µs 163.65 µs]
                        thrpt:  [5.9674 GiB/s 5.9682 GiB/s 5.9689 GiB/s]
                 change:
                        time:   [−7.6401% −7.5954% −7.5538%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1710% +8.2197% +8.2721%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```

</p>
</details> 

This is a port/upstreaming of my work on `fearless_simd`: https://github.com/linebender/fearless_simd/pull/276

Disassembly and llvm-mca measurements are from `fearless_simd` because this repo does not include instructions on how to disassemble and benchmark it (as opposed to the `std::simd` re-export of its older version).

Correctness of this formulation was verified using random testing against the scalar reference on 100k inputs: https://github.com/linebender/fearless_simd/pull/276/changes/4e8a56accb23ab4f0b96db89147b3c1fadc8f07e
On top of the usual unit tests.