### PR TITLE
Optimize swizzle_dyn on ssse3

### DIFF
--- a/crates/core_simd/src/swizzle_dyn.rs
+++ b/crates/core_simd/src/swizzle_dyn.rs
@@ -338,7 +338,8 @@ unsafe fn transize<T, const N: usize>(
 #[allow(unused)]
 #[inline(always)]
 fn zeroing_idxs<const N: usize>(idxs: Simd<u8, N>) -> Simd<u8, N> {
-    use crate::simd::{Select, cmp::SimdPartialOrd};
-    idxs.simd_lt(Simd::splat(N as u8))
-        .select(idxs, Simd::splat(u8::MAX))
+    // Adding this sets the high bit for indices N..=127, while PSHUFB ignores
+    // the other changed bits. The OR preserves the high bit for indices 128..=255.
+    let zeroing_bits = idxs + Simd::splat((127 - N + 1) as u8);
+    idxs | zeroing_bits
 }

--- a/crates/core_simd/tests/swizzle_dyn.rs
+++ b/crates/core_simd/tests/swizzle_dyn.rs
@@ -61,7 +61,7 @@ pub trait SwizzleStrategy {
 impl SwizzleStrategy for u8 {
     type Strategy = RangeInclusive<u8>;
     fn swizzled_strategy() -> Self::Strategy {
-        0..=64
+        0..=u8::MAX
     }
 }
 


### PR DESCRIPTION
The idea was [suggested](https://github.com/rust-lang/portable-simd/pull/542#issuecomment-5077221668) by @axnsan12. 

Changes the control sequence from vpcmpgtb + vpblendvb to vpaddb + vpor. 15% throughput improvement on Haswell, 20% improvement on skylake, zen1, zen3. For the 256-bit case, 38% improvement on haswell, 12% on skylake, zen1 and zen3 unchanged. Disassembly measured [on fealrless_simd](https://github.com/linebender/fearless_simd/pull/276) similarly to rust-lang/portable-simd#542.

Expands test coverage to cover byte values 128-255 which would misbehave without `idxs | zeroing_bits`.