### PR TITLE
gate `std_float` f16 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64-pc-windows-msvc, i686-pc-windows-msvc, x86_64-unknown-linux-gnu]
+        target: [x86_64-pc-windows-msvc, x86_64-pc-windows-gnu, i686-pc-windows-msvc, x86_64-unknown-linux-gnu]
         # `default` means we use the default target config for the target,
         # `native` means we run with `-Ctarget-cpu=native`, and anything else is
         # an arg to `-Ctarget-feature`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           # Populate the `matrix.os` field
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: x86_64-pc-windows-msvc,   os: windows-latest }
+          - { target: x86_64-pc-windows-gnu,    os: windows-latest }
           - { target: i686-pc-windows-msvc,     os: windows-latest }
 
           # Annoyingly, the x86_64-unknown-linux-gnu runner *almost* always has

--- a/crates/core_simd/tests/f16_ops.rs
+++ b/crates/core_simd/tests/f16_ops.rs
@@ -2,7 +2,7 @@
 #![feature(f16)]
 #![expect(internal_features)]
 #![feature(cfg_target_has_reliable_f16_f128)]
-
+#![allow(unused_features)]
 #[macro_use]
 mod ops_macros;
 

--- a/crates/std_float/Cargo.toml
+++ b/crates/std_float/Cargo.toml
@@ -18,3 +18,11 @@ wasm-bindgen-test = "0.3"
 [features]
 default = ["as_crate"]
 as_crate = []
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    # Internal features aren't marked known config by default, we use these to
+    # gate tests.
+    'cfg(target_has_reliable_f16_math)',
+]

--- a/crates/std_float/tests/float.rs
+++ b/crates/std_float/tests/float.rs
@@ -1,5 +1,8 @@
 #![feature(portable_simd)]
 #![feature(f16)]
+#![feature(cfg_target_has_reliable_f16_f128)]
+#![allow(internal_features)]
+#![allow(unused_features)]
 
 macro_rules! unary_test {
     { $scalar:tt, $($func:tt),+ } => {
@@ -87,6 +90,7 @@ macro_rules! impl_tests {
     }
 }
 
+#[cfg(target_has_reliable_f16_math)]
 impl_tests! { f16 }
 impl_tests! { f32 }
 impl_tests! { f64 }


### PR DESCRIPTION
turns out cranelift needs this too. I've also added a test run for `x86_64-pc-windows-gnu` which would have caught this much earlier.