### PR TITLE
Install cargo tools with locked dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Install Cross
         # Install the latest git version for newer targets.
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --rev 4090beca3cfffa44371a5bba524de3a578aa46c3
+          cargo install --locked cross --git https://github.com/cross-rs/cross --rev 4090beca3cfffa44371a5bba524de3a578aa46c3
 
       - name: Configure Emulated CPUs
         run: |


### PR DESCRIPTION
Installing cargo tools (`cargo install`) without locked dependencies exposes users to supply-chain attacks to all the dependencies of the tool (https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/). Using `cargo install --locked` reduces this risk to a compromise of the tool itself, while using the locked and hashed version of the dependencies.

I went through all `rg --hidden "cargo install"` hits in the repository and added `--locked` to all but explanatory examples (such as cargo's docs on `cargo install` itself). I validated that those tools publish functioning `Cargo.lock`s with https://gist.github.com/konstin/bcb1169c1c1120c259dca64e777a64d0.

See https://github.com/rust-lang/rust/pull/161428.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
